### PR TITLE
✨feat: 엔티티 기본 모델링 작성

### DIFF
--- a/src/main/java/site/festifriends/common/config/SecurityConfig.java
+++ b/src/main/java/site/festifriends/common/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package site.festifriends.config;
+package site.festifriends.common.config;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/site/festifriends/common/config/SwaggerConfig.java
+++ b/src/main/java/site/festifriends/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package site.festifriends.config;
+package site.festifriends.common.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/src/main/java/site/festifriends/common/model/BaseEntity.java
+++ b/src/main/java/site/festifriends/common/model/BaseEntity.java
@@ -1,0 +1,33 @@
+package site.festifriends.common.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Comment("생성 시간")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    @Comment("수정 시간")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/site/festifriends/common/model/SoftDeleteEntity.java
+++ b/src/main/java/site/festifriends/common/model/SoftDeleteEntity.java
@@ -1,0 +1,21 @@
+package site.festifriends.common.model;
+
+import jakarta.persistence.Column;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.Comment;
+
+public class SoftDeleteEntity extends BaseEntity {
+
+    @Column(name = "deleted")
+    @Comment("삭제 시간")
+    private LocalDateTime deleted;
+
+    public boolean isDeleted() {
+        return deleted != null;
+    }
+
+    public void delete() {
+        this.deleted = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/site/festifriends/entity/Festival.java
+++ b/src/main/java/site/festifriends/entity/Festival.java
@@ -1,0 +1,46 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.util.Date;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import site.festifriends.common.model.SoftDeleteEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "festival")
+public class Festival extends SoftDeleteEntity {
+
+    @Column(name = "title", nullable = false)
+    @Comment("공연 제목")
+    private String title;
+    @Column(name = "poster_url", nullable = false)
+    @Comment("공연 포스터 URL")
+    private String posterUrl;
+    @Column(name = "start_date", nullable = false)
+    @Comment("공연 시작 날짜")
+    private Date startDate;
+    @Column(name = "end_date", nullable = false)
+    @Comment("공연 종료 날짜")
+    private Date endDate;
+    @Column(name = "location", nullable = false)
+    @Comment("공연 장소(공연장명)")
+    private String location;
+    @Column(name = "cast", nullable = false)
+    @Comment("공연 출연진")
+    private String cast;
+    @Column(name = "price", nullable = false)
+    @Comment("티켓 가격")
+    private Integer price;
+    @Column(name = "state", nullable = false)
+    @Comment("공연 상태(공연 예정/공연 중/공연 종료)")
+    private String state;
+    @Column(name = "visit", nullable = false)
+    @Comment("내한 여부")
+    private Boolean visit;
+}

--- a/src/main/java/site/festifriends/entity/FestivalBookmark.java
+++ b/src/main/java/site/festifriends/entity/FestivalBookmark.java
@@ -1,0 +1,25 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.festifriends.common.model.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "festival_bookmark")
+public class FestivalBookmark extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Festival festival;
+}

--- a/src/main/java/site/festifriends/entity/FestivalBookmark.java
+++ b/src/main/java/site/festifriends/entity/FestivalBookmark.java
@@ -20,6 +20,6 @@ public class FestivalBookmark extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "festival_id", nullable = false)
     private Festival festival;
 }

--- a/src/main/java/site/festifriends/entity/Member.java
+++ b/src/main/java/site/festifriends/entity/Member.java
@@ -1,0 +1,45 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import site.festifriends.common.model.SoftDeleteEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+public class Member extends SoftDeleteEntity {
+
+    @Column(name = "email", nullable = false)
+    @Comment("이메일")
+    private String email;
+    @Column(name = "nickname", length = 20, nullable = false)
+    @Comment("닉네임")
+    private String nickname;
+    @Column(name = "profile_image_url", nullable = false)
+    @Comment("프로필 이미지 URL")
+    private String profileImageUrl;
+    @Column(name = "age", nullable = false)
+    @Comment("나이")
+    private Integer age;
+    @Column(name = "gender", length = 10, nullable = false)
+    @Comment("성별")
+    private String gender;
+    @Column(name = "introduce", length = 150)
+    @Comment("유저 자기소개")
+    private String introduction;
+    @Column(name = "tags", length = 1000)
+    @Comment("유저 태그(임시로 구분자를 통한 구분: ,)")
+    private String tags;
+    @Column(name = "sns", length = 1000)
+    @Comment("소셜 미디어 링크(임시로 구분자를 통해 구분: ,)")
+    private String sns;
+    @Column(name = "social_id", nullable = false)
+    @Comment("소셜 ID")
+    private String socialId;
+}

--- a/src/main/java/site/festifriends/entity/MemberParty.java
+++ b/src/main/java/site/festifriends/entity/MemberParty.java
@@ -1,0 +1,30 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import site.festifriends.common.model.SoftDeleteEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member_party")
+public class MemberParty extends SoftDeleteEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id", nullable = false)
+    private Party party;
+    @Column(name = "role", nullable = false)
+    @Comment("모임 내 역할(방장/일반)")
+    private String role;
+}

--- a/src/main/java/site/festifriends/entity/Notification.java
+++ b/src/main/java/site/festifriends/entity/Notification.java
@@ -1,0 +1,21 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import site.festifriends.common.model.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notification")
+public class Notification extends BaseEntity {
+
+    @Column(name = "type", nullable = false)
+    @Comment("알림 타입")
+    private String type;
+}

--- a/src/main/java/site/festifriends/entity/Party.java
+++ b/src/main/java/site/festifriends/entity/Party.java
@@ -1,0 +1,48 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import site.festifriends.common.model.SoftDeleteEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "party")
+public class Party extends SoftDeleteEntity {
+
+    @Column(name = "title", nullable = false)
+    @Comment("모임 이름")
+    private String title;
+    @Column(name = "gender_type", length = 10, nullable = false)
+    @Comment("모임 성별 구분(남자/여자/혼성)")
+    private String genderType;
+    @Column(name = "age_range", length = 20, nullable = false)
+    @Comment("모임 연령대(10대/20대/30대/40대/50대/60대 이상)")
+    private String ageRange;
+    @Column(name = "gather_type", length = 20, nullable = false)
+    @Comment("모임 방식(동행/탑승/숙박)")
+    private String gatherType;
+    @Column(name = "gather_date", nullable = false)
+    @Comment("모임 날짜")
+    private String gatherDate;
+    @Column(name = "location", nullable = false)
+    @Comment("모임 장소")
+    private String location;
+    @Column(name = "count", nullable = false)
+    @Comment("모임 인원 수")
+    private Integer count;
+    @Column(name = "introduction", length = 200, nullable = false)
+    @Comment("모임 소개")
+    private String introduction;
+    @Column(name = "hash_tags", length = 255)
+    @Comment("모임 해시태그(임시로 구분자를 통한 구분: ,)")
+    private String hashTags;
+    @Column(name = "announcement")
+    @Comment("모임 공지사항")
+    private String announcement;
+}

--- a/src/main/java/site/festifriends/entity/Report.java
+++ b/src/main/java/site/festifriends/entity/Report.java
@@ -1,0 +1,37 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import site.festifriends.common.model.SoftDeleteEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "report")
+public class Report extends SoftDeleteEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    @Comment("신고한 회원")
+    private Member member;
+    @Column(name = "target_id", nullable = false)
+    @Comment("신고 대상 ID")
+    private Long targetId;
+    @Column(name = "type", nullable = false)
+    @Comment("신고 타입(게시물, 채팅, 모임, 유저, 리뷰)")
+    private String type;
+    @Column(name = "reason", nullable = false)
+    @Comment("신고 사유")
+    private String reason;
+    @Column(name = "status", nullable = false)
+    @Comment("신고 상태(접수/처리 중/완료)")
+    private String status;
+}

--- a/src/main/java/site/festifriends/entity/Review.java
+++ b/src/main/java/site/festifriends/entity/Review.java
@@ -1,0 +1,24 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import site.festifriends.common.model.SoftDeleteEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "review")
+public class Review extends SoftDeleteEntity {
+
+    @Column(name = "content", nullable = false)
+    @Comment("리뷰 내용")
+    private String content;
+    @Column(name = "score", nullable = false)
+    @Comment("리뷰 점수(0.5점 단위)")
+    private Double score;
+}


### PR DESCRIPTION
## 작업 내용
- [🚚chore: config 파일 패키지 위치 변경](https://github.com/FestiFriends/ff_backend/commit/f5de5c59e2fbe2d9f6101ada5bbea980f8fba7d5)
  - 레이어드 아키텍쳐 형태의 구조로 변경
- [✨feat: 엔티티 Auditing 기본 모델 작성](https://github.com/FestiFriends/ff_backend/commit/ea1782d10698a0cd4179f5cc554d1d4f70aa31bf)  
  - 삭제 후 데이터가 유지되어야 하는 테이블의 경우 deleted_at을 두어 soft delete 진행(멤버, 공연, 모임 등)
  - 삭제 후에 데이터가 굳이 유지되지 않아도 되는 경우에는 hard delete를 진행할 수 있도록 설정(알림 등)
- [✨feat: 엔티티 기본 모델 작성](https://github.com/FestiFriends/ff_backend/commit/001c5d35cae2888ec6a16a38c4d1eca1faa79dba)
  - 기본 엔티티 작성만 진행하였습니다.
  - ```@ManyToOne```으로 매핑후, 추후 조회가 많이 필요한 데이터의 경우 ```@OneToMany``` 적용하도록 변경 필요할 것 같습니다.
  - 지연 로딩 전략을 적용했습니다.