### PR TITLE
✨feat: 카카오 소셜 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,46 +1,51 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.5'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.5'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'site.festifriends'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+
+    // jjwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  database:
+    container_name: ff-db
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: ff
+      TZ: Asia/Seoul
+    ports:
+      - "3311:3306"

--- a/src/main/java/site/festifriends/common/ResponseWrapper.java
+++ b/src/main/java/site/festifriends/common/ResponseWrapper.java
@@ -1,0 +1,34 @@
+package site.festifriends.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@JsonInclude(Include.NON_NULL)
+public class ResponseWrapper<T> {
+
+    private final Integer code;
+    private final String message;
+    private final T data;
+
+    private ResponseWrapper(Integer code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ResponseWrapper<T> noContent(HttpStatus status, String message) {
+        return new ResponseWrapper<>(status.value(), message, null);
+    }
+
+    public static <T> ResponseWrapper<T> success(HttpStatus status, String message, T data) {
+        return new ResponseWrapper<>(status.value(), message, data);
+    }
+
+    public static <T> ResponseWrapper<T> error(HttpStatus status, String message) {
+        return new ResponseWrapper<>(status.value(), message, null);
+    }
+
+}

--- a/src/main/java/site/festifriends/common/config/AuditConfig.java
+++ b/src/main/java/site/festifriends/common/config/AuditConfig.java
@@ -1,0 +1,10 @@
+package site.festifriends.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class AuditConfig {
+
+}

--- a/src/main/java/site/festifriends/common/config/RestClientConfig.java
+++ b/src/main/java/site/festifriends/common/config/RestClientConfig.java
@@ -1,0 +1,22 @@
+package site.festifriends.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean("oAuthRestClient")
+    public RestClient oAuthRestClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+
+        requestFactory.setConnectTimeout(3000);
+        requestFactory.setReadTimeout(10000);
+
+        return RestClient.builder()
+            .requestFactory(requestFactory)
+            .build();
+    }
+}

--- a/src/main/java/site/festifriends/common/config/SecurityConfig.java
+++ b/src/main/java/site/festifriends/common/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
         "/api-docs/**",
         "/v3/api-docs/**",
         "/swagger-ui/**", "/swagger",
+        "/api/v1/auth/**",
     };
 
     @Bean

--- a/src/main/java/site/festifriends/common/jwt/AccessTokenProvider.java
+++ b/src/main/java/site/festifriends/common/jwt/AccessTokenProvider.java
@@ -1,0 +1,80 @@
+package site.festifriends.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccessTokenProvider implements JwtTokenProvider {
+
+    @Value("${jwt.access.secret}")
+    private String accessSecretKey;
+    @Value("${jwt.access.expiration}")
+    private Long accessExpiration;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(accessSecretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String generateToken(Long memberId) {
+        return Jwts
+            .builder()
+            .header()
+            .type("JWT")
+            .and()
+            .issuer("festifriends")
+            .subject(memberId.toString())
+            .claim("tokenType", "access")
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + accessExpiration))
+            .signWith(key)
+            .compact();
+    }
+
+    @Override
+    public Boolean validateToken(String token) {
+        try {
+            Jwts
+                .parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String getSubject(String token) {
+        Claims claims = Jwts
+            .parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+
+        return claims.getSubject();
+    }
+
+    @Override
+    public Date getExpiration(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getExpiration();
+    }
+}

--- a/src/main/java/site/festifriends/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtTokenProvider.java
@@ -1,0 +1,14 @@
+package site.festifriends.common.jwt;
+
+import java.util.Date;
+
+public interface JwtTokenProvider {
+
+    String generateToken(Long memberId);
+
+    Boolean validateToken(String token);
+
+    String getSubject(String token);
+
+    Date getExpiration(String token);
+}

--- a/src/main/java/site/festifriends/common/jwt/RefreshTokenProvider.java
+++ b/src/main/java/site/festifriends/common/jwt/RefreshTokenProvider.java
@@ -1,0 +1,80 @@
+package site.festifriends.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenProvider implements JwtTokenProvider {
+
+    @Value("${jwt.refresh.secret}")
+    private String refreshSecretKey;
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshExpiration;
+
+    SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(refreshSecretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String generateToken(Long memberId) {
+        return Jwts
+            .builder()
+            .header()
+            .type("JWT")
+            .and()
+            .issuer("festifriends")
+            .subject(memberId.toString())
+            .claim("tokenType", "refresh")
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + refreshExpiration))
+            .signWith(key)
+            .compact();
+    }
+
+    @Override
+    public Boolean validateToken(String token) {
+        try {
+            Jwts
+                .parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String getSubject(String token) {
+        Claims claims = Jwts
+            .parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+
+        return claims.getSubject();
+    }
+
+    @Override
+    public Date getExpiration(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getExpiration();
+    }
+}

--- a/src/main/java/site/festifriends/common/model/BaseEntity.java
+++ b/src/main/java/site/festifriends/common/model/BaseEntity.java
@@ -7,11 +7,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {

--- a/src/main/java/site/festifriends/common/model/SoftDeleteEntity.java
+++ b/src/main/java/site/festifriends/common/model/SoftDeleteEntity.java
@@ -2,8 +2,10 @@ package site.festifriends.common.model;
 
 import jakarta.persistence.Column;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.hibernate.annotations.Comment;
 
+@Getter
 public class SoftDeleteEntity extends BaseEntity {
 
     @Column(name = "deleted")

--- a/src/main/java/site/festifriends/domain/auth/AuthInfo.java
+++ b/src/main/java/site/festifriends/domain/auth/AuthInfo.java
@@ -1,0 +1,14 @@
+package site.festifriends.domain.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthInfo {
+
+    private final String accessToken;
+    private final String refreshToken;
+    private final Boolean isNewUser;
+    
+}

--- a/src/main/java/site/festifriends/domain/auth/AuthResponse.java
+++ b/src/main/java/site/festifriends/domain/auth/AuthResponse.java
@@ -1,0 +1,12 @@
+package site.festifriends.domain.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthResponse {
+
+    private String accessToken;
+    private Boolean isNewUser;
+}

--- a/src/main/java/site/festifriends/domain/auth/KakaoOAuthProvider.java
+++ b/src/main/java/site/festifriends/domain/auth/KakaoOAuthProvider.java
@@ -1,0 +1,70 @@
+package site.festifriends.domain.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthProvider {
+
+    @Qualifier("oAuthRestClient")
+    private final RestClient restClient;
+
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String redirectUri;
+
+    private static final String AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize";
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    public String getAuthorizationUrl() {
+        return UriComponentsBuilder
+            .fromUriString(AUTHORIZE_URL)
+            .queryParam("response_type", "code")
+            .queryParam("client_id", clientId)
+            .queryParam("redirect_uri", redirectUri)
+            .build()
+            .toUriString();
+    }
+
+    public JsonNode getToken(String code) {
+        final String uri =
+            UriComponentsBuilder
+                .fromUriString(TOKEN_URL)
+                .queryParam("grant_type", "authorization_code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("code", code)
+                .build()
+                .toUriString();
+
+        return restClient
+            .post()
+            .uri(uri)
+            .retrieve()
+            .body(JsonNode.class);
+    }
+
+    public JsonNode getUserInfo(String code) {
+        JsonNode token = getToken(code);
+        return getUserInfoFromKakao(token.get("access_token").asText());
+    }
+
+    private JsonNode getUserInfoFromKakao(String accessToken) {
+        return restClient
+            .get()
+            .uri(USER_INFO_URL)
+            .header("Authorization", "Bearer " + accessToken)
+            .retrieve()
+            .body(JsonNode.class);
+    }
+
+}

--- a/src/main/java/site/festifriends/domain/auth/KakaoUserInfo.java
+++ b/src/main/java/site/festifriends/domain/auth/KakaoUserInfo.java
@@ -1,0 +1,20 @@
+package site.festifriends.domain.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Getter;
+
+@Getter
+public class KakaoUserInfo {
+
+    private String socialId;
+    private String name;
+    private String email;
+    private String profileImage;
+
+    public KakaoUserInfo(JsonNode userInfo) {
+        this.socialId = userInfo.get("id").asText();
+        this.name = userInfo.get("properties").get("nickname").asText();
+        this.email = userInfo.get("kakao_account").get("email").asText();
+        this.profileImage = userInfo.get("properties").get("profile_image").asText();
+    }
+}

--- a/src/main/java/site/festifriends/domain/auth/RefreshTokenCookieFactory.java
+++ b/src/main/java/site/festifriends/domain/auth/RefreshTokenCookieFactory.java
@@ -1,0 +1,20 @@
+package site.festifriends.domain.auth;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseCookie;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshTokenCookieFactory {
+
+    public static ResponseCookie create(String refreshToken) {
+        return ResponseCookie
+            .from("Refresh-Token", refreshToken)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .maxAge(60 * 60)
+            .sameSite("None")
+            .build();
+    }
+}

--- a/src/main/java/site/festifriends/domain/auth/controller/AuthApi.java
+++ b/src/main/java/site/festifriends/domain/auth/controller/AuthApi.java
@@ -1,0 +1,31 @@
+package site.festifriends.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "인증 관련 API", description = "카카오 소셜 로그인 및 인증 관련 API")
+public interface AuthApi {
+
+    @Operation(
+        summary = "카카오 로그인 요청",
+        description = "카카오 로그인 페이지로 리다이렉트합니다.",
+        responses = {
+            @ApiResponse(responseCode = "302", description = "카카오 로그인 페이지로 리다이렉트"),
+        }
+    )
+    ResponseEntity<?> login();
+
+    @Operation(
+        summary = "카카오 로그인 콜백 처리",
+        description = "카카오 로그인 후 콜백 URL에서 인증 코드를 받아 처리합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> handleCallback(@RequestParam String code);
+}

--- a/src/main/java/site/festifriends/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/festifriends/domain/auth/controller/AuthController.java
@@ -1,0 +1,51 @@
+package site.festifriends.domain.auth.controller;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.ResponseWrapper;
+import site.festifriends.domain.auth.AuthInfo;
+import site.festifriends.domain.auth.AuthResponse;
+import site.festifriends.domain.auth.RefreshTokenCookieFactory;
+import site.festifriends.domain.auth.service.AuthService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController implements AuthApi {
+
+    private final AuthService authService;
+
+    @Override
+    @GetMapping("/signup/kakao")
+    public ResponseEntity<?> login() {
+        return ResponseEntity
+            .status(HttpStatus.FOUND)
+            .location(URI.create(authService.getAuthorizationUrl()))
+            .build();
+    }
+
+    @Override
+    @GetMapping("/callback/kakao")
+    public ResponseEntity<?> handleCallback(@RequestParam String code) {
+        AuthInfo info = authService.handleOAuthCallback(code);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Set-Cookie", RefreshTokenCookieFactory.create(info.getRefreshToken()).toString());
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(ResponseWrapper.success(
+                HttpStatus.OK,
+                "로그인에 성공했습니다.",
+                new AuthResponse(info.getAccessToken(), info.getIsNewUser())
+            ));
+    }
+}

--- a/src/main/java/site/festifriends/domain/auth/service/AuthService.java
+++ b/src/main/java/site/festifriends/domain/auth/service/AuthService.java
@@ -1,0 +1,41 @@
+package site.festifriends.domain.auth.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.festifriends.common.jwt.AccessTokenProvider;
+import site.festifriends.common.jwt.RefreshTokenProvider;
+import site.festifriends.domain.auth.AuthInfo;
+import site.festifriends.domain.auth.KakaoOAuthProvider;
+import site.festifriends.domain.auth.KakaoUserInfo;
+import site.festifriends.domain.member.service.MemberService;
+import site.festifriends.entity.Member;
+import site.festifriends.entity.enums.Gender;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AccessTokenProvider accessTokenProvider;
+    private final RefreshTokenProvider refreshTokenProvider;
+    private final KakaoOAuthProvider kakaoOAuthProvider;
+    private final MemberService memberService;
+
+    public String getAuthorizationUrl() {
+        return kakaoOAuthProvider.getAuthorizationUrl();
+    }
+
+    public AuthInfo handleOAuthCallback(String code) {
+        JsonNode attributes = kakaoOAuthProvider.getUserInfo(code);
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(attributes);
+
+        Member member = memberService.loginOrSignUp(kakaoUserInfo);
+
+        String accessToken = accessTokenProvider.generateToken(member.getId());
+        String refreshToken = refreshTokenProvider.generateToken(member.getId());
+
+        memberService.saveRefreshToken(member, refreshToken);
+
+        return new AuthInfo(accessToken, refreshToken, member.getGender() == Gender.ALL);
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package site.festifriends.domain.member.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findBySocialId(String socialId);
+}

--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -1,0 +1,38 @@
+package site.festifriends.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.festifriends.domain.auth.KakaoUserInfo;
+import site.festifriends.domain.member.repository.MemberRepository;
+import site.festifriends.entity.Member;
+import site.festifriends.entity.enums.Gender;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member loginOrSignUp(KakaoUserInfo userInfo) {
+
+        return memberRepository.findBySocialId(userInfo.getSocialId())
+            .orElseGet(() -> {
+                Member newMember = Member.builder()
+                    .socialId(userInfo.getSocialId())
+                    .nickname(userInfo.getName())
+                    .email(userInfo.getEmail())
+                    .profileImageUrl(userInfo.getProfileImage())
+                    .age(0)
+                    .gender(Gender.ALL)
+                    .introduction("")
+                    .build();
+
+                return memberRepository.save(newMember);
+            });
+    }
+
+    public void saveRefreshToken(Member member, String refreshToken) {
+        member.updateRefreshToken(refreshToken);
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/site/festifriends/entity/Member.java
+++ b/src/main/java/site/festifriends/entity/Member.java
@@ -67,4 +67,12 @@ public class Member extends SoftDeleteEntity {
     @Column(name = "social_id", nullable = false)
     @Comment("소셜 ID")
     private String socialId;
+
+    @Column(name = "refresh_token")
+    @Comment("리프레시 토큰")
+    private String refreshToken;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/site/festifriends/entity/Member.java
+++ b/src/main/java/site/festifriends/entity/Member.java
@@ -11,6 +11,8 @@ import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -19,6 +21,8 @@ import site.festifriends.entity.enums.Gender;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
 public class Member extends SoftDeleteEntity {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,21 @@
 spring:
   application:
     name: FestiFriends
+  jpa:
+    show-sql: true
+    generate-ddl: false
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
+        format_sql: true
+    open-in-view: false
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
@@ -13,3 +28,34 @@ springdoc:
   api-docs:
     groups:
       enabled: true
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+
+jwt:
+  access:
+    secret: ${JWT_ACCESS_SECRET}
+    expiration: 3600000 # 1시간
+  refresh:
+    secret: ${JWT_REFRESH_SECRET}
+    expiration: 604800000 # 1주일
+
+---
+spring:
+  profiles:
+    active: prod
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+---
+spring:
+  profiles:
+    active: local
+  datasource:
+    url: jdbc:mysql://localhost:3311/ff
+    username: root
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 작업 내용
- [➕chore: jjwt 라이브러리 추가](https://github.com/FestiFriends/ff_backend/commit/e095632eb5840be8e87216c328cf1e4477887238)
  -  토큰 발급을 위해 최신 버전 jjwt 라이브러리를 적용했습니다
- [🔧feat: application 설정 파일 구성 추가](https://github.com/FestiFriends/ff_backend/commit/65f28ae2d2a5e93bb2c9a6630201fe1b754961af)
  - oauth, jwt ,db 관련 설정 값을 추가했습니다.
  - 환경변수는 우선은 현재 ec2 인스턴스 내부에서 수동으로 관리되고 있습니다.
- [🔧feat: 로컬 docker DB 사용을 위해 docker-compose.yml 파일 추가](https://github.com/FestiFriends/ff_backend/commit/f443ae081aa37655db5c17c6ae735048f673d87a) 
  - 로컬에서 도커를 이용해 DB를 사용하기 위해 docker-compose.yml을 간단히 작성했습니다.
 - [✨feat: Audit,RestClient 설정 파일 추가](https://github.com/FestiFriends/ff_backend/commit/793a0d9b25da7acca3c9dc3ece90cdae97b25f77)
- [✨feat: 기본 엔티티 Getter 추가 및 Member Builder 패턴 추가](https://github.com/FestiFriends/ff_backend/commit/1ec963510b609b3301676dd3b8a0d771dee01b4f) 
  - ```BaseEntity```, ```SoftEntity```에 ```Getter```가 없어서 JPA에서 사용되지 못하는 부분을 수정했습니다.
  - ```Member``` 객체를 쉽게 만들 수 있도록 빌더 패턴을 적용했습니다.
- [✨feat: 클라이언트측으로 보낼 공통 응답 설정](https://github.com/FestiFriends/ff_backend/commit/7edc835b9adb2c3d09b31419b606c2668ce2b8ce)
  - 노션 API 문서를 바탕으로 클라이언트 측으로 보낼 공통 응답을 정의했습니다.
  - 현재는 Exception이 구성되어 있지 않아 추후 ErrorCode가 추가되면 error 메소드 변수를 변경할 예정입니다.
- [✨feat: 카카오 소셜 로그인 구현](https://github.com/FestiFriends/ff_backend/commit/08864d2014cfa17bf9a6d84f05b5bc04bb38c9b9)
  - 카카오 소셜 로그인 기능을 구현했습니다. 관련 환경변수를 노션 및 ec2 인스턴스 내부에 업데이트 완료했습니다.
  - 액세스토큰은 body, 리프레쉬토큰은 cookie를 통해 클라이언트 측으로 전달됩니다.
  - 현재 callback url이 정의되어 있지 않아 임시로 백엔드 주소로 지정했습니다.(추후 변경 예정)
  - Redis를 사용하지 않아 refreshToken을 저장할 컬럼을 추가로 Member 엔티티에 추가했습니다.

## 리뷰 포인트
- CI/CD 및 환경변수 관리를 어떻게 하면 좋을까요? (저는 Github Actions 사용해봤습니다.)
- 새로운 회원인지 아닌지를 Gender 타입을 통해서 판별하고 있는데 다른 좋은 방법이 있을까요?
- 빠르게 기능을 구현하기 위해 급하게 작성했는데, 변경되면 좋은 점이 보이시면 말씀해주시면 추후 리팩토링 진행하겠습니다.
- 추후 진행 예정으로, 인증 필터 작성 / 회원 정보 추가 기입 / 로그아웃 구현 예정입니다.
