### PR TITLE
✨feat: JWT 필터 추가 및 에러 핸들러 설정

### DIFF
--- a/src/main/java/site/festifriends/common/ErrorCode.java
+++ b/src/main/java/site/festifriends/common/ErrorCode.java
@@ -1,0 +1,19 @@
+package site.festifriends.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ErrorCode {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/site/festifriends/common/GlobalExceptionHandler.java
+++ b/src/main/java/site/festifriends/common/GlobalExceptionHandler.java
@@ -1,0 +1,51 @@
+package site.festifriends.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({
+        MethodArgumentNotValidException.class,
+        MissingServletRequestParameterException.class,
+        MissingRequestHeaderException.class,
+        BindException.class,
+        TypeMismatchException.class,
+        MethodArgumentTypeMismatchException.class
+    })
+    protected ResponseEntity<ResponseWrapper<?>> handleValidException(
+        MethodArgumentNotValidException e) {
+        log.warn("handleValidException : {}", e.getMessage());
+        return ResponseEntity.status(e.getStatusCode()).body(ResponseWrapper.error(ErrorCode.BAD_REQUEST));
+    }
+
+    @ExceptionHandler({
+        NoHandlerFoundException.class,
+        NoResourceFoundException.class
+    })
+    protected ResponseEntity<ResponseWrapper<?>> handleNotFoundException(Exception e) {
+        log.warn("handleNotFoundException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ResponseWrapper.error(ErrorCode.NOT_FOUND));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ResponseWrapper<?>> handleException(Exception e) {
+        log.error("handleException : {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ResponseWrapper.error(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+}

--- a/src/main/java/site/festifriends/common/ResponseWrapper.java
+++ b/src/main/java/site/festifriends/common/ResponseWrapper.java
@@ -27,8 +27,8 @@ public class ResponseWrapper<T> {
         return new ResponseWrapper<>(status.value(), message, data);
     }
 
-    public static <T> ResponseWrapper<T> error(HttpStatus status, String message) {
-        return new ResponseWrapper<>(status.value(), message, null);
+    public static <T> ResponseWrapper<T> error(ErrorCode errorCode) {
+        return new ResponseWrapper<>(errorCode.getStatus().value(), errorCode.getMessage(), null);
     }
 
 }

--- a/src/main/java/site/festifriends/common/config/JwtFilterConfig.java
+++ b/src/main/java/site/festifriends/common/config/JwtFilterConfig.java
@@ -1,0 +1,38 @@
+package site.festifriends.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import site.festifriends.common.jwt.JwtAuthenticationFilter;
+import site.festifriends.common.jwt.JwtExceptionFilter;
+import site.festifriends.common.jwt.JwtTokenProvider;
+import site.festifriends.domain.auth.service.CustomUserDetailsService;
+
+@Configuration
+public class JwtFilterConfig {
+
+    private final ObjectMapper objectMapper;
+    private final CustomUserDetailsService userDetailsService;
+    private final JwtTokenProvider accessTokenProvider;
+
+    JwtFilterConfig(
+        ObjectMapper objectMapper,
+        CustomUserDetailsService userDetailsService,
+        @Qualifier("accessTokenProvider") JwtTokenProvider accessTokenProvider
+    ) {
+        this.objectMapper = objectMapper;
+        this.userDetailsService = userDetailsService;
+        this.accessTokenProvider = accessTokenProvider;
+    }
+
+    @Bean
+    public JwtExceptionFilter jwtExceptionFilter() {
+        return new JwtExceptionFilter(objectMapper);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(accessTokenProvider, userDetailsService);
+    }
+}

--- a/src/main/java/site/festifriends/common/jwt/AccessTokenProvider.java
+++ b/src/main/java/site/festifriends/common/jwt/AccessTokenProvider.java
@@ -77,4 +77,15 @@ public class AccessTokenProvider implements JwtTokenProvider {
             .getPayload()
             .getExpiration();
     }
+
+    @Override
+    public String getTokenType(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get("tokenType", String.class);
+    }
 }

--- a/src/main/java/site/festifriends/common/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,24 @@
+package site.festifriends.common.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException
+    ) throws IOException {
+        log.error("handle error: {}", accessDeniedException.getMessage());
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/site/festifriends/common/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package site.festifriends.common.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+        log.error("commence error: {}", authException.getMessage());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/site/festifriends/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtAuthenticationFilter.java
@@ -26,8 +26,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws ServletException, IOException {
 
-        log.info("uri: {}", request.getRequestURI());
-
         String accessToken = extractAccessToken(request);
 
         if (accessToken != null && !accessToken.isEmpty()) {

--- a/src/main/java/site/festifriends/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package site.festifriends.common.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.auth.service.CustomUserDetailsService;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider accessTokenProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        log.info("uri: {}", request.getRequestURI());
+
+        String accessToken = extractAccessToken(request);
+
+        if (accessToken != null && !accessToken.isEmpty()) {
+            try {
+                String accessTokenType = accessTokenProvider.getTokenType(accessToken);
+                if ("access".equals(accessTokenType)) {
+                    UserDetailsImpl userDetails = getUserDetails(accessToken);
+                    setAuthenticationUser(userDetails, request);
+                }
+            } catch (ExpiredJwtException e1) {
+                throw new ServletException();
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractAccessToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            return authorizationHeader.substring(7);
+        }
+        return null;
+    }
+
+    private UserDetailsImpl getUserDetails(String accessToken) {
+        Long userId = Long.valueOf(accessTokenProvider.getSubject(accessToken));
+
+        return userDetailsService.loadUserById(userId);
+    }
+
+    private void setAuthenticationUser(UserDetailsImpl userDetails, HttpServletRequest request) {
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+            userDetails, null, userDetails.getAuthorities()
+        );
+
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/site/festifriends/common/jwt/JwtExceptionFilter.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtExceptionFilter.java
@@ -1,0 +1,34 @@
+package site.festifriends.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+import site.festifriends.common.ErrorCode;
+import site.festifriends.common.ResponseWrapper;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            log.error("JWT Exception: {}", e.getMessage(), e);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            objectMapper.writeValue(response.getWriter(),
+                ResponseWrapper.error(ErrorCode.UNAUTHORIZED));
+        }
+    }
+}

--- a/src/main/java/site/festifriends/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtTokenProvider.java
@@ -11,4 +11,6 @@ public interface JwtTokenProvider {
     String getSubject(String token);
 
     Date getExpiration(String token);
+
+    String getTokenType(String token);
 }

--- a/src/main/java/site/festifriends/common/jwt/RefreshTokenProvider.java
+++ b/src/main/java/site/festifriends/common/jwt/RefreshTokenProvider.java
@@ -77,4 +77,15 @@ public class RefreshTokenProvider implements JwtTokenProvider {
             .getPayload()
             .getExpiration();
     }
+
+    @Override
+    public String getTokenType(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get("tokenType", String.class);
+    }
 }

--- a/src/main/java/site/festifriends/domain/auth/UserDetailsImpl.java
+++ b/src/main/java/site/festifriends/domain/auth/UserDetailsImpl.java
@@ -1,0 +1,37 @@
+package site.festifriends.domain.auth;
+
+import java.util.Collection;
+import java.util.Collections;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import site.festifriends.entity.Member;
+
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+    private final Member member;
+
+    public UserDetailsImpl(Member member) {
+        this.member = member;
+    }
+
+    public static UserDetailsImpl of(Member member) {
+        return new UserDetailsImpl(member);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getNickname();
+    }
+}

--- a/src/main/java/site/festifriends/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/site/festifriends/domain/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,21 @@
+package site.festifriends.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.member.repository.MemberRepository;
+import site.festifriends.entity.Member;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    public UserDetailsImpl loadUserById(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다 : " + memberId));
+
+        return UserDetailsImpl.of(member);
+    }
+}


### PR DESCRIPTION
## 작업내용
- [✨feat: 오류 응답을 위해 공통응답 수정 및 에러 코드 및 핸들러 추가](https://github.com/FestiFriends/ff_backend/commit/be7aab44d00c90db7681687aec55ce3ba2f420c8)
  - 에러 발생 시 클라이언트 측에 공통적으로 응답을 전달하기 위해 핸들러를 추가했습니다.
  - 공통응답 클래스 ```error()``` 메소드에서 HttpStatus가 아닌 ErrorCode를 생성자로 사용하게 변경해, 추후 에러 관리를 용이하게 하였습니다.
- [✨feat: Jwt tokenType 을 가져오는 로직 추가](https://github.com/FestiFriends/ff_backend/commit/bd06d5eea5d44af76b2ad526b759ab7029eafc83)
  - JWT필터 혹은 AccessToken 재발급 시 tokenType을 판별하기 위해 TokenProvider에 메소드를 추가했습니다.
- [✨feat: Jwt 필터 추가 및 설정](https://github.com/FestiFriends/ff_backend/commit/f69277b9eb4916cfdaccd936973a5d131fc3d97d)
  - Jwt 필터를 추가하고 SecurityConfig에 필터를 적용했습니다.
  - ```UserDetailsImpl``` 에서 DB에서 가져온 ```Member``` 객체를 그대로 담도록 설정했습니다.
  - 현재는 권한이 별도로 필요할 것이라 생각하지 않아 미적용했습니다.
 

## 리뷰 포인트
- 현재 블랙리스트 토큰을 별도로 적용하고 있지 않아 로그아웃 혹은 AccessToken 재발급 시 애로사항이 있을 것으로 예상됩니다. 별도의 테이블 을 적용하는 방법이 어떨까 싶습니다.
- 디렉토리 혹은 코드의 전체적인 구조를 조금 더 깔끔하게 할 수 있는 방법이 있을 지 말씀해주시면 감사하겠습니다.