### PR TITLE
✨feat: 회원 로그아웃 및 탈퇴 기능 작성

### DIFF
--- a/src/main/java/site/festifriends/common/jwt/AccessTokenProvider.java
+++ b/src/main/java/site/festifriends/common/jwt/AccessTokenProvider.java
@@ -42,7 +42,7 @@ public class AccessTokenProvider implements JwtTokenProvider {
     }
 
     @Override
-    public Boolean validateToken(String token) {
+    public boolean validateToken(String token) {
         try {
             Jwts
                 .parser()

--- a/src/main/java/site/festifriends/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtTokenProvider.java
@@ -6,7 +6,7 @@ public interface JwtTokenProvider {
 
     String generateToken(Long memberId);
 
-    Boolean validateToken(String token);
+    boolean validateToken(String token);
 
     String getSubject(String token);
 

--- a/src/main/java/site/festifriends/common/jwt/RefreshTokenProvider.java
+++ b/src/main/java/site/festifriends/common/jwt/RefreshTokenProvider.java
@@ -42,7 +42,7 @@ public class RefreshTokenProvider implements JwtTokenProvider {
     }
 
     @Override
-    public Boolean validateToken(String token) {
+    public boolean validateToken(String token) {
         try {
             Jwts
                 .parser()

--- a/src/main/java/site/festifriends/common/jwt/TokenResolver.java
+++ b/src/main/java/site/festifriends/common/jwt/TokenResolver.java
@@ -1,0 +1,26 @@
+package site.festifriends.common.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class TokenResolver {
+
+    public static String extractAccessToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            return authorizationHeader.substring(7);
+        }
+        return null;
+    }
+
+    public static String extractRefreshToken(HttpServletRequest request) {
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("Refresh-Token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/site/festifriends/domain/auth/RefreshTokenCookieFactory.java
+++ b/src/main/java/site/festifriends/domain/auth/RefreshTokenCookieFactory.java
@@ -13,7 +13,7 @@ public class RefreshTokenCookieFactory {
             .httpOnly(true)
             .secure(true)
             .path("/")
-            .maxAge(60 * 60)
+            .maxAge(60 * 60 * 24 * 7)
             .sameSite("None")
             .build();
     }

--- a/src/main/java/site/festifriends/domain/auth/UserDetailsImpl.java
+++ b/src/main/java/site/festifriends/domain/auth/UserDetailsImpl.java
@@ -10,14 +10,16 @@ import site.festifriends.entity.Member;
 @Getter
 public class UserDetailsImpl implements UserDetails {
 
-    private final Member member;
+    private final Long memberId;
+    private final String nickname;
 
-    public UserDetailsImpl(Member member) {
-        this.member = member;
+    public UserDetailsImpl(Long memberId, String nickname) {
+        this.memberId = memberId;
+        this.nickname = nickname;
     }
 
     public static UserDetailsImpl of(Member member) {
-        return new UserDetailsImpl(member);
+        return new UserDetailsImpl(member.getId(), member.getNickname());
     }
 
     @Override
@@ -32,6 +34,6 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public String getUsername() {
-        return member.getNickname();
+        return this.nickname;
     }
 }

--- a/src/main/java/site/festifriends/domain/auth/controller/AuthApi.java
+++ b/src/main/java/site/festifriends/domain/auth/controller/AuthApi.java
@@ -3,8 +3,11 @@ package site.festifriends.domain.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
+import site.festifriends.domain.auth.UserDetailsImpl;
 
 @Tag(name = "인증 관련 API", description = "카카오 소셜 로그인 및 인증 관련 API")
 public interface AuthApi {
@@ -28,4 +31,25 @@ public interface AuthApi {
         }
     )
     ResponseEntity<?> handleCallback(@RequestParam String code);
+
+    @Operation(
+        summary = "로그아웃",
+        description = "사용자의 토큰을 무효화하고 로그아웃합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> logout(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletRequest request);
+
+    @Operation(
+        summary = "액세스 토큰 재발급",
+        description = "리프레시 토큰을 사용하여 액세스 토큰을 재발급합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "액세스 토큰 재발급 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> reissueAccessToken(@AuthenticationPrincipal UserDetailsImpl userDetails,
+        HttpServletRequest request);
 }

--- a/src/main/java/site/festifriends/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/festifriends/domain/auth/controller/AuthController.java
@@ -1,11 +1,13 @@
 package site.festifriends.domain.auth.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +15,7 @@ import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.AuthInfo;
 import site.festifriends.domain.auth.AuthResponse;
 import site.festifriends.domain.auth.RefreshTokenCookieFactory;
+import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.auth.service.AuthService;
 
 @RestController
@@ -35,6 +38,33 @@ public class AuthController implements AuthApi {
     @GetMapping("/callback/kakao")
     public ResponseEntity<?> handleCallback(@RequestParam String code) {
         AuthInfo info = authService.handleOAuthCallback(code);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Set-Cookie", RefreshTokenCookieFactory.create(info.getRefreshToken()).toString());
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(ResponseWrapper.success(
+                HttpStatus.OK,
+                "로그인에 성공했습니다.",
+                new AuthResponse(info.getAccessToken(), info.getIsNewUser())
+            ));
+    }
+
+    @Override
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(UserDetailsImpl userDetails, HttpServletRequest request) {
+        authService.logout(userDetails.getMemberId(), request);
+
+        return ResponseEntity.ok()
+            .body(ResponseWrapper.noContent(HttpStatus.OK, "로그아웃에 성공했습니다."));
+    }
+
+    @Override
+    @PostMapping("/token")
+    public ResponseEntity<?> reissueAccessToken(UserDetailsImpl userDetails, HttpServletRequest request) {
+        AuthInfo info = authService.reissueAccessToken(userDetails.getMemberId(), request);
 
         HttpHeaders headers = new HttpHeaders();
 

--- a/src/main/java/site/festifriends/domain/auth/repository/BlackListTokenRepository.java
+++ b/src/main/java/site/festifriends/domain/auth/repository/BlackListTokenRepository.java
@@ -1,0 +1,9 @@
+package site.festifriends.domain.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.BlackListToken;
+
+public interface BlackListTokenRepository extends JpaRepository<BlackListToken, Long> {
+
+    boolean existsByToken(String token);
+}

--- a/src/main/java/site/festifriends/domain/auth/service/AuthService.java
+++ b/src/main/java/site/festifriends/domain/auth/service/AuthService.java
@@ -1,10 +1,12 @@
 package site.festifriends.domain.auth.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.festifriends.common.jwt.AccessTokenProvider;
 import site.festifriends.common.jwt.RefreshTokenProvider;
+import site.festifriends.common.jwt.TokenResolver;
 import site.festifriends.domain.auth.AuthInfo;
 import site.festifriends.domain.auth.KakaoOAuthProvider;
 import site.festifriends.domain.auth.KakaoUserInfo;
@@ -20,6 +22,7 @@ public class AuthService {
     private final RefreshTokenProvider refreshTokenProvider;
     private final KakaoOAuthProvider kakaoOAuthProvider;
     private final MemberService memberService;
+    private final BlackListTokenService blackListTokenService;
 
     public String getAuthorizationUrl() {
         return kakaoOAuthProvider.getAuthorizationUrl();
@@ -34,8 +37,51 @@ public class AuthService {
         String accessToken = accessTokenProvider.generateToken(member.getId());
         String refreshToken = refreshTokenProvider.generateToken(member.getId());
 
-        memberService.saveRefreshToken(member, refreshToken);
+        memberService.saveRefreshToken(member.getId(), refreshToken);
 
         return new AuthInfo(accessToken, refreshToken, member.getGender() == Gender.ALL);
+    }
+
+    public AuthInfo reissueAccessToken(Long memberId, HttpServletRequest request) {
+        String refreshToken = TokenResolver.extractRefreshToken(request);
+
+        validateRefreshToken(refreshToken, memberId);
+
+        blackListTokenService.addBlackListToken(refreshToken);
+
+        String newAccessToken = accessTokenProvider.generateToken(memberId);
+        String newRefreshToken = refreshTokenProvider.generateToken(memberId);
+
+        memberService.saveRefreshToken(memberId, newRefreshToken);
+
+        return new AuthInfo(newAccessToken, newRefreshToken, false);
+    }
+
+    private void validateRefreshToken(String refreshToken, Long memberId) {
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new IllegalArgumentException("Refresh token is missing.");
+        }
+        if (!refreshTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("Invalid refresh token.");
+        }
+        if (!refreshTokenProvider.getSubject(refreshToken).equals(memberId.toString())) {
+            throw new IllegalArgumentException("Refresh token does not match the user ID.");
+        }
+        if (blackListTokenService.isBlackListed(refreshToken)) {
+            throw new IllegalArgumentException("Refresh token is blacklisted.");
+        }
+    }
+
+    public void logout(Long memberId, HttpServletRequest request) {
+        String accessToken = TokenResolver.extractAccessToken(request);
+        String refreshToken = TokenResolver.extractRefreshToken(request);
+
+        if (!accessTokenProvider.getSubject(accessToken).equals(memberId.toString()) ||
+            !refreshTokenProvider.getSubject(refreshToken).equals(memberId.toString())) {
+            throw new IllegalArgumentException("Access token or refresh token does not match the user ID.");
+        }
+
+        blackListTokenService.addBlackListToken(accessToken);
+        blackListTokenService.addBlackListToken(refreshToken);
     }
 }

--- a/src/main/java/site/festifriends/domain/auth/service/BlackListTokenService.java
+++ b/src/main/java/site/festifriends/domain/auth/service/BlackListTokenService.java
@@ -1,0 +1,21 @@
+package site.festifriends.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.festifriends.domain.auth.repository.BlackListTokenRepository;
+import site.festifriends.entity.BlackListToken;
+
+@Service
+@RequiredArgsConstructor
+public class BlackListTokenService {
+
+    private final BlackListTokenRepository blackListTokenRepository;
+
+    public void addBlackListToken(String token) {
+        blackListTokenRepository.save(new BlackListToken(token));
+    }
+
+    public boolean isBlackListed(String token) {
+        return blackListTokenRepository.existsByToken(token);
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
@@ -1,0 +1,21 @@
+package site.festifriends.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import site.festifriends.domain.auth.UserDetailsImpl;
+
+public interface MemberApi {
+
+    @Operation(
+        summary = "회원 탈퇴",
+        description = "회원 탈퇴 API. Access Token을 받아 해당 회원을 삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> deleteMember(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletRequest request);
+}

--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package site.festifriends.domain.member.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.ResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.member.service.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class MemberController implements MemberApi {
+
+    private final MemberService memberService;
+
+    @Override
+    @DeleteMapping("/me")
+    public ResponseEntity<?> deleteMember(UserDetailsImpl userDetails, HttpServletRequest request) {
+        memberService.deleteMember(userDetails.getMemberId(), request);
+
+        return ResponseEntity.ok().body(ResponseWrapper.success("회원 탈퇴가 완료되었습니다."));
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepository.java
@@ -2,9 +2,15 @@ package site.festifriends.domain.member.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import site.festifriends.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findBySocialId(String socialId);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.deleted = CURRENT_TIMESTAMP WHERE m = :member")
+    void deleteMember(Member member);
 }

--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -1,8 +1,11 @@
 package site.festifriends.domain.member.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import site.festifriends.common.jwt.TokenResolver;
 import site.festifriends.domain.auth.KakaoUserInfo;
+import site.festifriends.domain.auth.service.BlackListTokenService;
 import site.festifriends.domain.member.repository.MemberRepository;
 import site.festifriends.entity.Member;
 import site.festifriends.entity.enums.Gender;
@@ -12,6 +15,7 @@ import site.festifriends.entity.enums.Gender;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final BlackListTokenService blackListTokenService;
 
     public Member loginOrSignUp(KakaoUserInfo userInfo) {
 
@@ -31,8 +35,23 @@ public class MemberService {
             });
     }
 
-    public void saveRefreshToken(Member member, String refreshToken) {
+    public void saveRefreshToken(Long memberId, String refreshToken) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다"));
         member.updateRefreshToken(refreshToken);
         memberRepository.save(member);
+    }
+
+    public void deleteMember(Long memberId, HttpServletRequest request) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다"));
+
+        memberRepository.deleteMember(member);
+
+        String accessToken = TokenResolver.extractAccessToken(request);
+        String refreshToken = TokenResolver.extractRefreshToken(request);
+
+        blackListTokenService.addBlackListToken(accessToken);
+        blackListTokenService.addBlackListToken(refreshToken);
     }
 }

--- a/src/main/java/site/festifriends/entity/BlackListToken.java
+++ b/src/main/java/site/festifriends/entity/BlackListToken.java
@@ -1,0 +1,25 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.festifriends.common.model.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "black_list_token")
+public class BlackListToken extends BaseEntity {
+
+    private String token;
+
+    public BlackListToken(String token) {
+        this.token = token;
+    }
+
+    public void updateToken(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/site/festifriends/entity/BlackListToken.java
+++ b/src/main/java/site/festifriends/entity/BlackListToken.java
@@ -1,6 +1,10 @@
 package site.festifriends.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -13,6 +17,12 @@ import site.festifriends.common.model.BaseEntity;
 @Table(name = "black_list_token")
 public class BlackListToken extends BaseEntity {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "blacklist_token_id", nullable = false)
+    private Long id;
+
+    @Column(name = "token")
     private String token;
 
     public BlackListToken(String token) {


### PR DESCRIPTION
## 작업내용

- [✨feat: 블랙리스트 토큰 엔티티 추가](https://github.com/FestiFriends/ff_backend/commit/75fe523576c26fb5813a349bf9c17a945715badb)
  - 토큰 무효화를 위한 블랙리스트 토큰 테이블을 추가했습니다.
  - 캐시를 사용하지 않아 별도의 테이블로 구성하였습니다.
- [✨feat: 토큰 추출을 위한 Resolver 작성](https://github.com/FestiFriends/ff_backend/commit/efd17e7f1171cfa4ca03bb0c8a8ec4d60bcd62dd)
  - 전역적으로 `HttpServletRequest`에서 헤더 및 쿠키에서 토큰을 추출할 수 있도록 작성했습니다.
- [✨feat: 회원탈퇴 로직 추가](https://github.com/FestiFriends/ff_backend/commit/428048e9b867426b6d63669de0672e83b604ebe0)
  - 회원탈퇴 시 soft delete을 할 수 있도록 적용했습니다.
  - 회원탈퇴 시 기존의 토큰을 블랙리스트 토큰으로 등록했습니다.
- [✨feat: 액세스 토큰 재발급 로직 추가](https://github.com/FestiFriends/ff_backend/commit/37fd7f9bfa256a34c7b97ee1335aa1357cb8c85a)
  - 로그아웃 및 액세스토큰 재발급 로직을 추가했습니다.
  - 로그아웃 / 액세스토큰 재발급 시 기존의 토큰을 블랙리스트 토큰으로 등록하여 관리하도록 설정하였습니다.