### PR TITLE
🐛fix: 토큰 재발급 로직 오류 해결

### DIFF
--- a/src/main/java/site/festifriends/common/config/SecurityConfig.java
+++ b/src/main/java/site/festifriends/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package site.festifriends.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +27,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
+    private final ObjectMapper objectMapper;
 
     private final String[] readOnlyUrl = {
         "/favicon.ico",
@@ -56,8 +58,8 @@ public class SecurityConfig {
                     .anyRequest().authenticated())
             .exceptionHandling(exception ->
                 exception
-                    .accessDeniedHandler(new JwtAccessDeniedHandler())
-                    .authenticationEntryPoint(new JwtAuthenticationEntryPoint()));
+                    .accessDeniedHandler(new JwtAccessDeniedHandler(objectMapper))
+                    .authenticationEntryPoint(new JwtAuthenticationEntryPoint(objectMapper)));
 
         return http.build();
     }

--- a/src/main/java/site/festifriends/common/config/SecurityConfig.java
+++ b/src/main/java/site/festifriends/common/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                 authorizeHttpRequests
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                     .requestMatchers(HttpMethod.GET, readOnlyUrl).permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/auth/token").permitAll()
                     .anyRequest().authenticated())
             .exceptionHandling(exception ->
                 exception

--- a/src/main/java/site/festifriends/common/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtAccessDeniedHandler.java
@@ -1,16 +1,23 @@
 package site.festifriends.common.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
+import site.festifriends.common.exception.ErrorCode;
+import site.festifriends.common.response.ResponseWrapper;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(
@@ -18,7 +25,13 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         HttpServletResponse response,
         AccessDeniedException accessDeniedException
     ) throws IOException {
-        log.error("handle error: {}", accessDeniedException.getMessage());
+        log.warn("Access denied: {}, method={}, uri={}",
+            accessDeniedException.getMessage(),
+            request.getMethod(),
+            request.getRequestURI());
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json; charset=UTF-8");
+        objectMapper.writeValue(response.getWriter(), ResponseWrapper.error(ErrorCode.FORBIDDEN));
         response.sendError(HttpServletResponse.SC_FORBIDDEN);
     }
 }

--- a/src/main/java/site/festifriends/common/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtAuthenticationEntryPoint.java
@@ -1,22 +1,34 @@
 package site.festifriends.common.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+import site.festifriends.common.exception.ErrorCode;
+import site.festifriends.common.response.ResponseWrapper;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException authException) throws IOException, ServletException {
-        log.error("commence error: {}", authException.getMessage());
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        log.warn("commence error: {}, method={}, uri={}",
+            authException.getMessage(),
+            request.getMethod(),
+            request.getRequestURI());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json; charset=UTF-8");
+        objectMapper.writeValue(response.getWriter(), ResponseWrapper.error(ErrorCode.UNAUTHORIZED));
     }
 }

--- a/src/main/java/site/festifriends/common/jwt/JwtExceptionFilter.java
+++ b/src/main/java/site/festifriends/common/jwt/JwtExceptionFilter.java
@@ -26,7 +26,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         } catch (Exception e) {
             log.error("JWT Exception: {}", e.getMessage(), e);
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json");
+            response.setContentType("application/json; charset=UTF-8");
             objectMapper.writeValue(response.getWriter(),
                 ResponseWrapper.error(ErrorCode.UNAUTHORIZED));
         }

--- a/src/main/java/site/festifriends/domain/auth/controller/AuthApi.java
+++ b/src/main/java/site/festifriends/domain/auth/controller/AuthApi.java
@@ -50,6 +50,5 @@ public interface AuthApi {
             @ApiResponse(responseCode = "401", description = "인증 실패"),
         }
     )
-    ResponseEntity<?> reissueAccessToken(@AuthenticationPrincipal UserDetailsImpl userDetails,
-        HttpServletRequest request);
+    ResponseEntity<?> reissueAccessToken(HttpServletRequest request);
 }

--- a/src/main/java/site/festifriends/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/festifriends/domain/auth/controller/AuthController.java
@@ -63,8 +63,8 @@ public class AuthController implements AuthApi {
 
     @Override
     @PostMapping("/token")
-    public ResponseEntity<?> reissueAccessToken(UserDetailsImpl userDetails, HttpServletRequest request) {
-        AuthInfo info = authService.reissueAccessToken(userDetails.getMemberId(), request);
+    public ResponseEntity<?> reissueAccessToken(HttpServletRequest request) {
+        AuthInfo info = authService.reissueAccessToken(request);
 
         HttpHeaders headers = new HttpHeaders();
 


### PR DESCRIPTION
## 작업 내용
- [🚑fix: 토큰 재발급 시 인증 객체를 사용하지 않도록 변경](https://github.com/FestiFriends/ff_backend/commit/cd4086b67d3ef22b10a28e9e57f586104ad22c20)
  - AT가 만료되어 인증 객체를 사용할 수 없음에도, 컨트롤러에서 인증객체를 사용하는 문제가 있어 인증 객체 파라미터를 제거했습니다.
- [🚑fix: 불필요한 토큰 유효 검사 제거 및 에러 응답 변경](https://github.com/FestiFriends/ff_backend/commit/c8a08065426ebddf052857babe061d483818aeb7)
  - 인증 객체가 제거됨에 따라 리프레쉬토큰의 subject와 memberId를 비교하는 로직을 제거하였습니다.
- [✨feat: 만료된 액세스 토큰을 사용해야 하는 경우 filter 에서 무시하도록 설정 추가](https://github.com/FestiFriends/ff_backend/commit/cc18784cf6fa89aed8dfc082c2d15bea1e75147c)
  - 만료된 액세스 토큰이 들어올 경우 필터에서 항상 에러가 발생하게 되는데, 토큰 재발급로직은 이를 우회하도록 설정하였습니다.
- [✨feat: JwtAuthenticationEntryPoint 및 JwtAccessDeniedHandler 공통응답 전달하도록 설정](https://github.com/FestiFriends/ff_backend/commit/edd7e22a31bd73c17148d99f13cab9deba73d98f)
  - UTF-8 형식 및 공통응답 형태로 Jwt 필터 에러 상황에서도 응답을 정상적으로 전달하도록 설정했습니다.