### PR TITLE
✨feat: 모임 가입 신청취소 기능 및 유저 찜(위시리스트) 기능 관련 작성

### DIFF
--- a/src/main/java/site/festifriends/domain/application/controller/ApplicationApi.java
+++ b/src/main/java/site/festifriends/domain/application/controller/ApplicationApi.java
@@ -109,4 +109,22 @@ public interface ApplicationApi {
         @Parameter(description = "신청서 ID")
         @PathVariable Long applicationId
     );
+
+    @Operation(
+        summary = "모임 가입 신청 취소&확정안함",
+        description = "신청자가 모임 신청을 취소합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "모임 신청서 취소 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "권한이 없는 사용자 (신청자만 가능)"),
+            @ApiResponse(responseCode = "404", description = "신청서를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    ResponseEntity<ResponseWrapper<ApplicationStatusResponse>> cancelApplication(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "신청서 ID")
+        @PathVariable Long applicationId
+    );
 } 

--- a/src/main/java/site/festifriends/domain/application/controller/ApplicationController.java
+++ b/src/main/java/site/festifriends/domain/application/controller/ApplicationController.java
@@ -3,6 +3,7 @@ package site.festifriends.domain.application.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -89,5 +90,13 @@ public class ApplicationController implements ApplicationApi {
             applicationService.confirmApplication(user.getMemberId(), applicationId);
 
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @DeleteMapping("/applied/{applicationId}")
+    public ResponseEntity<ResponseWrapper<ApplicationStatusResponse>> cancelApplication(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long applicationId) {
+        return ResponseEntity.ok(applicationService.cancelApplication(user.getMemberId(), applicationId));
     }
 } 

--- a/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
+++ b/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
@@ -357,6 +357,30 @@ public class ApplicationService {
         return ResponseWrapper.success("모임 가입을 확정하였습니다", response);
     }
 
+    /**
+     * 모임 신청 취소&확정안함
+     */
+    public ResponseWrapper<ApplicationStatusResponse> cancelApplication(Long memberId, Long applicationId) {
+        MemberGroup application = applicationRepository.findById(applicationId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "신청서를 찾을 수 없습니다."));
+
+        validateApplicantPermission(memberId, application);
+
+        if (application.getStatus() == ApplicationStatus.PENDING) {
+            application.cancel();
+        } else if (application.getStatus() == ApplicationStatus.ACCEPTED) {
+            application.cancel();
+        } else {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "취소할 수 없는 신청서 상태입니다.");
+        }
+
+        ApplicationStatusResponse response = ApplicationStatusResponse.builder()
+            .result(true)
+            .build();
+
+        return ResponseWrapper.success("모임 가입 신청이 취소되었습니다", response);
+    }
+
     private void validateHostPermission(Long hostId, MemberGroup application) {
         boolean isHost = applicationRepository.existsByGroupIdAndMemberIdAndRole(
             application.getGroup().getId(),
@@ -374,4 +398,4 @@ public class ApplicationService {
             throw new BusinessException(ErrorCode.FORBIDDEN, "본인의 신청서만 확정할 수 있습니다.");
         }
     }
-} 
+}

--- a/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
@@ -1,10 +1,12 @@
 package site.festifriends.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
 import site.festifriends.domain.auth.UserDetailsImpl;
 
 public interface MemberApi {
@@ -18,4 +20,40 @@ public interface MemberApi {
         }
     )
     ResponseEntity<?> deleteMember(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletRequest request);
+
+    @Operation(
+        summary = "내가 찜한 사용자 목록 조회",
+        description = "내가 찜한 사용자 목록을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "찜한 사용자 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> getMyLikedMembers(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Parameter(description = "커서 Id, default는 첫번째 요소")
+        @RequestParam(required = false) Long cursorId,
+        @Parameter(description = "한 페이지당 항목 수, default는 20")
+        @RequestParam(defaultValue = "20") int size
+    );
+
+    @Operation(
+        summary = "내가 찜한 사용자 수",
+        description = "내가 찜한 사용자 수를 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "찜한 사용자 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> getMyLikedMembersCount(@AuthenticationPrincipal UserDetailsImpl userDetails);
+
+    @Operation(
+        summary = "찜한 공연 목록 조회",
+        description = "내가 찜한 공연 목록을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "찜한 사용자 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> getMyLikedPerformances(@AuthenticationPrincipal UserDetailsImpl userDetails);
 }

--- a/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
@@ -55,5 +55,11 @@ public interface MemberApi {
             @ApiResponse(responseCode = "401", description = "인증 실패"),
         }
     )
-    ResponseEntity<?> getMyLikedPerformances(@AuthenticationPrincipal UserDetailsImpl userDetails);
+    ResponseEntity<?> getMyLikedPerformances(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Parameter(description = "커서 Id, default는 첫번째 요소")
+        @RequestParam(required = false) Long cursorId,
+        @Parameter(description = "한 페이지당 항목 수, default는 20")
+        @RequestParam(defaultValue = "20") int size
+    );
 }

--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -54,7 +54,6 @@ public class MemberController implements MemberApi {
         @RequestParam(required = false) Long cursorId,
         @RequestParam(defaultValue = "20") int size
     ) {
-        memberService.getMyLikedPerformances(userDetails.getMemberId(), cursorId, size);
-        return null;
+        return ResponseEntity.ok(memberService.getMyLikedPerformances(userDetails.getMemberId(), cursorId, size));
     }
 }

--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -9,8 +9,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.member.dto.MemberDto;
 import site.festifriends.domain.member.service.MemberService;
 
 @RestController
@@ -31,7 +33,7 @@ public class MemberController implements MemberApi {
 
     @Override
     @GetMapping("/favorites")
-    public ResponseEntity<?> getMyLikedMembers(
+    public ResponseEntity<CursorResponseWrapper<MemberDto>> getMyLikedMembers(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestParam(required = false) Long cursorId,
         @RequestParam(defaultValue = "20") int size) {
@@ -39,8 +41,10 @@ public class MemberController implements MemberApi {
     }
 
     @Override
+    @GetMapping("/favorites/count")
     public ResponseEntity<?> getMyLikedMembersCount(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return null;
+        Long count = memberService.getMyLikedMembersCount(userDetails.getMemberId());
+        return ResponseEntity.ok(ResponseWrapper.success("요청이 성공적으로 처리되었습니다.", count));
     }
 
     @Override

--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package site.festifriends.domain.member.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +20,8 @@ public class MemberController implements MemberApi {
 
     @Override
     @DeleteMapping("/me")
-    public ResponseEntity<?> deleteMember(UserDetailsImpl userDetails, HttpServletRequest request) {
+    public ResponseEntity<?> deleteMember(@AuthenticationPrincipal UserDetailsImpl userDetails,
+        HttpServletRequest request) {
         memberService.deleteMember(userDetails.getMemberId(), request);
 
         return ResponseEntity.ok().body(ResponseWrapper.success("회원 탈퇴가 완료되었습니다."));

--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -5,7 +5,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
@@ -25,5 +27,24 @@ public class MemberController implements MemberApi {
         memberService.deleteMember(userDetails.getMemberId(), request);
 
         return ResponseEntity.ok().body(ResponseWrapper.success("회원 탈퇴가 완료되었습니다."));
+    }
+
+    @Override
+    @GetMapping("/favorites")
+    public ResponseEntity<?> getMyLikedMembers(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam(required = false) Long cursorId,
+        @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(memberService.getMyLikedMembers(userDetails.getMemberId(), cursorId, size));
+    }
+
+    @Override
+    public ResponseEntity<?> getMyLikedMembersCount(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<?> getMyLikedPerformances(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return null;
     }
 }

--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
-import site.festifriends.domain.member.dto.MemberDto;
+import site.festifriends.domain.member.dto.LikedMemberResponse;
 import site.festifriends.domain.member.service.MemberService;
 
 @RestController
@@ -33,7 +33,7 @@ public class MemberController implements MemberApi {
 
     @Override
     @GetMapping("/favorites")
-    public ResponseEntity<CursorResponseWrapper<MemberDto>> getMyLikedMembers(
+    public ResponseEntity<CursorResponseWrapper<LikedMemberResponse>> getMyLikedMembers(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestParam(required = false) Long cursorId,
         @RequestParam(defaultValue = "20") int size) {
@@ -48,7 +48,13 @@ public class MemberController implements MemberApi {
     }
 
     @Override
-    public ResponseEntity<?> getMyLikedPerformances(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    @GetMapping("/performances/favorites")
+    public ResponseEntity<?> getMyLikedPerformances(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam(required = false) Long cursorId,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        memberService.getMyLikedPerformances(userDetails.getMemberId(), cursorId, size);
         return null;
     }
 }

--- a/src/main/java/site/festifriends/domain/member/dto/LikedMemberDto.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedMemberDto.java
@@ -1,0 +1,20 @@
+package site.festifriends.domain.member.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikedMemberDto {
+
+    private String name;
+    private String gender;
+    private Integer age;
+    private String userUid;
+    private Boolean isUserNew;
+    private String profileImage;
+    private List<String> hashtag;
+    private Long bookmarkId;
+
+}

--- a/src/main/java/site/festifriends/domain/member/dto/LikedMemberResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedMemberResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class MemberDto {
+public class LikedMemberResponse {
 
     private String name;
     private String gender;

--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceDto.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceDto.java
@@ -1,0 +1,32 @@
+package site.festifriends.domain.member.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikedPerformanceDto {
+
+    private Long id;
+    private String title;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String location;
+    private List<String> cast;
+    private List<String> crew;
+    private String runtime;
+    private String age;
+    private List<String> productionCompany;
+    private List<String> agency;
+    private List<String> host;
+    private List<String> organizer;
+    private List<String> price;
+    private String poster;
+    private String state;
+    private String visit;
+    private List<LikedPerformanceImageDto> images;
+    private List<LocalDateTime> time;
+    private Long bookmarkId;
+}

--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceGroupCountDto.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceGroupCountDto.java
@@ -1,0 +1,11 @@
+package site.festifriends.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikedPerformanceGroupCountDto {
+
+    private Long count;
+}

--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceImageDto.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceImageDto.java
@@ -1,0 +1,15 @@
+package site.festifriends.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LikedPerformanceImageDto {
+
+    private String id;
+    private String src;
+    private String alt;
+}

--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
@@ -28,4 +28,5 @@ public class LikedPerformanceResponse {
     private String visit;
     private List<LikedPerformanceImageDto> images;
     private List<LocalDateTime> time;
+    private Integer groupCount;
 }

--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
@@ -1,0 +1,31 @@
+package site.festifriends.domain.member.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikedPerformanceResponse {
+
+    private Long id;
+    private String title;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String location;
+    private List<String> cast;
+    private List<String> crew;
+    private String runtime;
+    private String age;
+    private List<String> productionCompany;
+    private List<String> agency;
+    private List<String> host;
+    private List<String> organizer;
+    private List<String> price;
+    private String poster;
+    private String state;
+    private String visit;
+    private List<LikedPerformanceImageDto> images;
+    private List<LocalDateTime> time;
+}

--- a/src/main/java/site/festifriends/domain/member/dto/MemberDto.java
+++ b/src/main/java/site/festifriends/domain/member/dto/MemberDto.java
@@ -1,0 +1,18 @@
+package site.festifriends.domain.member.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberDto {
+
+    private String name;
+    private String gender;
+    private Integer age;
+    private String userUid;
+    private Boolean isUserNew;
+    private String profileImage;
+    private List<String> hashtag;
+}

--- a/src/main/java/site/festifriends/domain/member/repository/BookmarkRepository.java
+++ b/src/main/java/site/festifriends/domain/member/repository/BookmarkRepository.java
@@ -1,0 +1,8 @@
+package site.festifriends.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.Bookmark;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+}

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import site.festifriends.entity.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
     Optional<Member> findBySocialId(String socialId);
 

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
@@ -1,11 +1,11 @@
 package site.festifriends.domain.member.repository;
 
 import org.springframework.data.domain.Pageable;
-import site.festifriends.common.response.CursorResponseWrapper;
-import site.festifriends.domain.member.dto.MemberDto;
+import org.springframework.data.domain.Slice;
+import site.festifriends.domain.member.dto.LikedMemberDto;
 
 public interface MemberRepositoryCustom {
 
-    CursorResponseWrapper<MemberDto> getMyLikedMembers(Long memberId, Long cursorId, Pageable pageable);
+    Slice<LikedMemberDto> getMyLikedMembers(Long memberId, Long cursorId, Pageable pageable);
 
 }

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
@@ -8,4 +8,5 @@ public interface MemberRepositoryCustom {
 
     Slice<LikedMemberDto> getMyLikedMembers(Long memberId, Long cursorId, Pageable pageable);
 
+    Long countMyLikedMembers(Long memberId);
 }

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,11 @@
+package site.festifriends.domain.member.repository;
+
+import org.springframework.data.domain.Pageable;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.member.dto.MemberDto;
+
+public interface MemberRepositoryCustom {
+
+    CursorResponseWrapper<MemberDto> getMyLikedMembers(Long memberId, Long cursorId, Pageable pageable);
+
+}

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
@@ -3,10 +3,13 @@ package site.festifriends.domain.member.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import site.festifriends.domain.member.dto.LikedMemberDto;
+import site.festifriends.domain.member.dto.LikedPerformanceDto;
 
 public interface MemberRepositoryCustom {
 
     Slice<LikedMemberDto> getMyLikedMembers(Long memberId, Long cursorId, Pageable pageable);
 
     Long countMyLikedMembers(Long memberId);
+
+    Slice<LikedPerformanceDto> getMyLikedPerformances(Long memberId, Long cursorId, Pageable pageable);
 }

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
@@ -3,8 +3,11 @@ package site.festifriends.domain.member.repository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +16,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 import site.festifriends.domain.member.dto.LikedMemberDto;
+import site.festifriends.domain.member.dto.LikedPerformanceDto;
+import site.festifriends.domain.member.dto.LikedPerformanceImageDto;
 
 @Repository
 @RequiredArgsConstructor
@@ -79,12 +84,143 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         Query query = em.createNativeQuery(sql);
 
         query.setParameter("memberId", memberId);
-        
+
         List<Long> resultList = query.getResultList();
         if (resultList.isEmpty()) {
             return 0L;
         }
 
         return resultList.get(0);
+    }
+
+    @Override
+    public Slice<LikedPerformanceDto> getMyLikedPerformances(Long memberId, Long cursorId, Pageable pageable) {
+        int pageSize = pageable.getPageSize() + 1;
+
+        String sql = """
+            SELECT p.performance_id, p.title, p.start_date, p.end_date, p.location,
+            GROUP_CONCAT(DISTINCT c.cast_member ORDER BY c.order_index) AS `cast`,
+            GROUP_CONCAT(DISTINCT cr.crew_member ORDER BY cr.order_index) AS crew,
+            p.runtime, p.age, GROUP_CONCAT(DISTINCT pc.company ORDER BY pc.order_index) AS production_company,
+            GROUP_CONCAT(DISTINCT a.agency ORDER BY a.order_index) AS agency,
+            GROUP_CONCAT(DISTINCT h.host ORDER BY h.order_index) AS host,
+            GROUP_CONCAT(DISTINCT o.organizer ORDER BY o.order_index) AS organizer,
+            GROUP_CONCAT(DISTINCT pr.price ORDER BY pr.order_index) AS price,
+            p.poster_url, p.state, p.visit,
+            GROUP_CONCAT(DISTINCT CONCAT(pi.performance_image_id, '|', pi.src, '|', IFNULL(pi.alt, ''))) AS images,
+            GROUP_CONCAT(DISTINCT pt.time ORDER BY pt.order_index) AS time,
+            b.bookmark_id
+            FROM bookmark b
+            JOIN performance p ON b.target_id = p.performance_id
+            LEFT JOIN performance_cast c ON p.performance_id = c.performance_id
+            LEFT JOIN performance_crew cr ON p.performance_id = cr.performance_id
+            LEFT JOIN performance_production_company pc ON p.performance_id = pc.performance_id
+            LEFT JOIN performance_agency a ON p.performance_id = a.performance_id
+            LEFT JOIN performance_host h ON p.performance_id = h.performance_id
+            LEFT JOIN performance_organizer o ON p.performance_id = o.performance_id
+            LEFT JOIN performance_price pr ON p.performance_id = pr.performance_id
+            LEFT JOIN performance_image pi ON p.performance_id = pi.performance_id
+            LEFT JOIN performance_time pt ON p.performance_id = pt.performance_id
+            WHERE b.member_id = :memberId
+            AND b.type = 'PERFORMANCE'
+            AND (:cursorId IS NULL OR b.bookmark_id < :cursorId)
+            GROUP BY p.performance_id, p.title, p.start_date, p.end_date, p.location,
+            p.runtime, p.age, p.poster_url, p.state, p.visit, b.bookmark_id
+            ORDER BY b.bookmark_id DESC
+            LIMIT :pageSize
+            """;
+
+        Query query = em.createNativeQuery(sql);
+
+        query.setParameter("memberId", memberId);
+        query.setParameter("cursorId", cursorId);
+        query.setParameter("pageSize", pageSize);
+        List<Object[]> resultList = query.getResultList();
+
+        List<LikedPerformanceDto> dtos = resultList.stream()
+            .map(row -> {
+                Long id = ((Number) row[0]).longValue();
+                String title = (String) row[1];
+                LocalDateTime startDate = toLocalDateTime(row[2]);
+                LocalDateTime endDate = toLocalDateTime(row[3]);
+                String location = (String) row[4];
+
+                List<String> cast = splitToList((String) row[5]);
+                List<String> crew = splitToList((String) row[6]);
+                String runtime = (String) row[7];
+                String age = (String) row[8];
+                List<String> productionCompany = splitToList((String) row[9]);
+                List<String> agency = splitToList((String) row[10]);
+                List<String> host = splitToList((String) row[11]);
+                List<String> organizer = splitToList((String) row[12]);
+                List<String> price = splitToList((String) row[13]);
+                String poster = (String) row[14];
+                String state = String.valueOf(row[15]);
+                String visit = (String) row[16];
+
+                List<LikedPerformanceImageDto> images = parseImages((String) row[17]);
+                List<LocalDateTime> time = splitToLocalDateTimeList((String) row[18]);
+
+                Long bookmarkId = row[19] == null ? null : ((Number) row[19]).longValue();
+
+                return new LikedPerformanceDto(
+                    id, title, startDate, endDate, location, cast, crew, runtime, age,
+                    productionCompany, agency, host, organizer, price, poster, state, visit,
+                    images, time, bookmarkId
+                );
+            })
+            .collect(Collectors.toList());
+
+        boolean hasNext = dtos.size() == pageSize;
+
+        return new SliceImpl<>(dtos, pageable, hasNext);
+    }
+
+    private List<String> splitToList(String value) {
+        if (value == null || value.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList(value.split(","));
+    }
+
+    private List<LocalDateTime> splitToLocalDateTimeList(String value) {
+        if (value == null || value.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(value.split(","))
+            .map(String::trim)
+            .map(v -> LocalDateTime.parse(v, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+            .collect(Collectors.toList());
+    }
+
+    private List<LikedPerformanceImageDto> parseImages(String value) {
+        if (value == null || value.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return Arrays.stream(value.split(","))
+            .map(img -> {
+                String[] parts = img.split("\\|");
+                String id = parts.length > 0 ? parts[0] : null;
+                String src = parts.length > 1 ? parts[1] : null;
+                String alt = parts.length > 2 ? parts[2] : null;
+                return LikedPerformanceImageDto.builder()
+                    .id(id)
+                    .src(src)
+                    .alt(alt)
+                    .build();
+            })
+            .collect(Collectors.toList());
+    }
+
+    private LocalDateTime toLocalDateTime(Object obj) {
+        if (obj == null) {
+            return null;
+        }
+        if (obj instanceof java.sql.Timestamp ts) {
+            return ts.toLocalDateTime();
+        } else if (obj instanceof LocalDateTime ldt) {
+            return ldt;
+        }
+        return null;
     }
 }

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
@@ -66,4 +66,25 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
 
         return new SliceImpl<>(dtos, pageable, hasNext);
     }
+
+    @Override
+    public Long countMyLikedMembers(Long memberId) {
+        String sql = """
+            SELECT COUNT(*)
+            FROM bookmark b
+            WHERE b.member_id = :memberId
+            AND b.type = 'MEMBER'
+            """;
+
+        Query query = em.createNativeQuery(sql);
+
+        query.setParameter("memberId", memberId);
+        
+        List<Long> resultList = query.getResultList();
+        if (resultList.isEmpty()) {
+            return 0L;
+        }
+
+        return resultList.get(0);
+    }
 }

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,81 @@
+package site.festifriends.domain.member.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.member.dto.MemberDto;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public CursorResponseWrapper<MemberDto> getMyLikedMembers(Long memberId, Long cursorId, Pageable pageable) {
+        int pageSize = pageable.getPageSize() + 1;
+
+        List<Long> bookmarkIds = new ArrayList<>();
+
+        String sql = """
+            SELECT m.nickname, m.gender, m.age, m.member_id, m.profile_image_url, GROUP_CONCAT(mt.tag) as tags, b.bookmark_id
+            FROM bookmark b
+            JOIN member m ON b.member_id = m.member_id
+            LEFT JOIN member_tags mt ON m.member_id = mt.member_id
+            WHERE b.member_id = :memberId
+            AND b.type = 'MEMBER'
+            AND (:cursorId IS NULL OR b.bookmark_id < :cursorId)
+            GROUP BY m.nickname, m.gender, m.age, m.member_id, m.profile_image_url, b.bookmark_id
+            ORDER BY b.bookmark_id DESC
+            LIMIT :pageSize
+            """;
+
+        Query query = em.createNativeQuery(sql);
+
+        query.setParameter("memberId", memberId);
+        query.setParameter("cursorId", cursorId);
+        query.setParameter("pageSize", pageSize);
+
+        List<Object[]> resultList = query.getResultList();
+
+        List<MemberDto> members = resultList.stream()
+            .map(row -> {
+                bookmarkIds.add(((Number) row[6]).longValue());
+                return new MemberDto(
+                    (String) row[0],
+                    (String) row[1],
+                    (Integer) row[2],
+                    row[3].toString(),
+                    false,
+                    (String) row[4],
+                    row[5] == null ? new ArrayList<>() :
+                        Arrays.stream(((String) row[5]).split(","))
+                            .map(tag -> "#" + tag)
+                            .collect(Collectors.toList())
+                );
+            })
+            .collect(Collectors.toList());
+
+        Long nextCursorId = bookmarkIds.size() == pageSize ? bookmarkIds.get(pageSize - 1) : null;
+        boolean hasNext = members.size() == pageSize;
+        if (hasNext) {
+            members.remove(pageSize - 1);
+        }
+
+        return CursorResponseWrapper.success(
+            "요청이 성공적으로 처리되었습니다.",
+            members,
+            nextCursorId,
+            hasNext
+        );
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -99,6 +99,10 @@ public class MemberService {
         );
     }
 
+    public Long getMyLikedMembersCount(Long memberId) {
+        return memberRepository.countMyLikedMembers(memberId);
+    }
+
     public Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다."));

--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -2,10 +2,14 @@ package site.festifriends.domain.member.service;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import site.festifriends.common.jwt.TokenResolver;
+import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.domain.auth.KakaoUserInfo;
 import site.festifriends.domain.auth.service.BlackListTokenService;
+import site.festifriends.domain.member.dto.MemberDto;
 import site.festifriends.domain.member.repository.MemberRepository;
 import site.festifriends.entity.Member;
 import site.festifriends.entity.enums.Gender;
@@ -54,4 +58,12 @@ public class MemberService {
         blackListTokenService.addBlackListToken(accessToken);
         blackListTokenService.addBlackListToken(refreshToken);
     }
+
+    public CursorResponseWrapper<MemberDto> getMyLikedMembers(Long memberId, Long cursorId, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        return memberRepository.getMyLikedMembers(memberId, cursorId, pageable);
+
+    }
+
 }

--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -15,7 +15,9 @@ import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.domain.auth.KakaoUserInfo;
 import site.festifriends.domain.auth.service.BlackListTokenService;
 import site.festifriends.domain.member.dto.LikedMemberDto;
-import site.festifriends.domain.member.dto.MemberDto;
+import site.festifriends.domain.member.dto.LikedMemberResponse;
+import site.festifriends.domain.member.dto.LikedPerformanceDto;
+import site.festifriends.domain.member.dto.LikedPerformanceResponse;
 import site.festifriends.domain.member.repository.MemberRepository;
 import site.festifriends.entity.Member;
 import site.festifriends.entity.enums.Gender;
@@ -63,7 +65,7 @@ public class MemberService {
         blackListTokenService.addBlackListToken(refreshToken);
     }
 
-    public CursorResponseWrapper<MemberDto> getMyLikedMembers(Long memberId, Long cursorId, int size) {
+    public CursorResponseWrapper<LikedMemberResponse> getMyLikedMembers(Long memberId, Long cursorId, int size) {
         Pageable pageable = PageRequest.of(0, size);
 
         Slice<LikedMemberDto> slice = memberRepository.getMyLikedMembers(memberId, cursorId, pageable);
@@ -72,10 +74,10 @@ public class MemberService {
             return CursorResponseWrapper.empty("요청이 성공적으로 처리되었습니다.");
         }
 
-        List<MemberDto> response = new ArrayList<>();
+        List<LikedMemberResponse> response = new ArrayList<>();
 
         for (LikedMemberDto likedMember : slice.getContent()) {
-            response.add(new MemberDto(
+            response.add(new LikedMemberResponse(
                 likedMember.getName(),
                 likedMember.getGender(),
                 likedMember.getAge(),
@@ -101,6 +103,57 @@ public class MemberService {
 
     public Long getMyLikedMembersCount(Long memberId) {
         return memberRepository.countMyLikedMembers(memberId);
+    }
+
+    public CursorResponseWrapper<LikedPerformanceResponse> getMyLikedPerformances(Long memberId, Long cursorId,
+        int size) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        Slice<LikedPerformanceDto> slice = memberRepository.getMyLikedPerformances(memberId, cursorId, pageable);
+
+        if (slice.isEmpty()) {
+            return CursorResponseWrapper.empty("요청이 성공적으로 처리되었습니다.");
+        }
+
+        List<LikedPerformanceResponse> response = new ArrayList<>();
+
+        for (LikedPerformanceDto likedPerformance : slice.getContent()) {
+            response.add(new LikedPerformanceResponse(
+                likedPerformance.getId(),
+                likedPerformance.getTitle(),
+                likedPerformance.getStartDate(),
+                likedPerformance.getEndDate(),
+                likedPerformance.getLocation(),
+                likedPerformance.getCast(),
+                likedPerformance.getCrew(),
+                likedPerformance.getRuntime(),
+                likedPerformance.getAge(),
+                likedPerformance.getProductionCompany(),
+                likedPerformance.getAgency(),
+                likedPerformance.getHost(),
+                likedPerformance.getOrganizer(),
+                likedPerformance.getPrice(),
+                likedPerformance.getPoster(),
+                likedPerformance.getState(),
+                likedPerformance.getVisit(),
+                likedPerformance.getImages(),
+                likedPerformance.getTime()
+            ));
+        }
+
+        Long nextCursorId = null;
+
+        if (slice.hasNext()) {
+            response.remove(response.size() - 1);
+            nextCursorId = slice.getContent().get(size).getBookmarkId();
+        }
+
+        return CursorResponseWrapper.success(
+            "요청이 성공적으로 처리되었습니다.",
+            response,
+            nextCursorId,
+            slice.hasNext()
+        );
     }
 
     public Member getMemberById(Long memberId) {

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceImageRepository.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceImageRepository.java
@@ -1,0 +1,8 @@
+package site.festifriends.domain.performance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.PerformanceImage;
+
+public interface PerformanceImageRepository extends JpaRepository<PerformanceImage, Long> {
+
+}

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
@@ -1,16 +1,17 @@
 package site.festifriends.domain.performance.repository;
 
+import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.entity.Performance;
 
-import java.util.List;
-import java.util.Map;
-
 public interface PerformanceRepositoryCustom {
-    
+
     Page<Performance> searchPerformancesWithPaging(PerformanceSearchRequest request, Pageable pageable);
-    
+
     Map<Long, Long> findGroupCountsByPerformanceIds(List<Long> performanceIds);
-} 
+
+    Map<Long, Integer> getGroupCountsByPerformanceIds(List<Long> performanceIds);
+}

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryImpl.java
@@ -1,8 +1,13 @@
 package site.festifriends.domain.performance.repository;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -13,11 +18,6 @@ import site.festifriends.entity.Performance;
 import site.festifriends.entity.QGroup;
 import site.festifriends.entity.QPerformance;
 import site.festifriends.entity.QPerformanceImage;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -31,16 +31,16 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
         QPerformanceImage pi = QPerformanceImage.performanceImage;
 
         JPAQuery<Performance> query = queryFactory
-                .selectFrom(p)
-                .leftJoin(p.imgs, pi).fetchJoin()
-                .where(
-                        titleContains(request.getTitle()),
-                        locationContains(request.getLocation()),
-                        visitEquals(request.getVisit()),
-                        dateRangeFilter(request.getStartDate(), request.getEndDate()),
-                        notDeleted()
-                )
-                .distinct();
+            .selectFrom(p)
+            .leftJoin(p.imgs, pi).fetchJoin()
+            .where(
+                titleContains(request.getTitle()),
+                locationContains(request.getLocation()),
+                visitEquals(request.getVisit()),
+                dateRangeFilter(request.getStartDate(), request.getEndDate()),
+                notDeleted()
+            )
+            .distinct();
 
         // 정렬 적용
         query = applySorting(query, request.getSort());
@@ -50,9 +50,9 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 
         // 페이징 적용하여 결과 조회
         List<Performance> performances = query
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
 
         return new PageImpl<>(performances, pageable, total);
     }
@@ -62,43 +62,66 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
         QGroup g = QGroup.group;
 
         List<Object[]> results = queryFactory
-                .select(g.performance.id, g.count())
-                .from(g)
-                .where(
-                        g.performance.id.in(performanceIds),
-                        g.deleted.isNull()
-                )
-                .groupBy(g.performance.id)
-                .fetch()
-                .stream()
-                .map(tuple -> new Object[]{tuple.get(g.performance.id), tuple.get(g.count())})
-                .collect(Collectors.toList());
+            .select(g.performance.id, g.count())
+            .from(g)
+            .where(
+                g.performance.id.in(performanceIds),
+                g.deleted.isNull()
+            )
+            .groupBy(g.performance.id)
+            .fetch()
+            .stream()
+            .map(tuple -> new Object[]{tuple.get(g.performance.id), tuple.get(g.count())})
+            .collect(Collectors.toList());
 
         return results.stream()
-                .collect(Collectors.toMap(
-                        result -> (Long) result[0],
-                        result -> (Long) result[1]
-                ));
+            .collect(Collectors.toMap(
+                result -> (Long) result[0],
+                result -> (Long) result[1]
+            ));
+    }
+
+    @Override
+    public Map<Long, Integer> getGroupCountsByPerformanceIds(List<Long> performanceIds) {
+        List<Tuple> result = queryFactory
+            .select(QGroup.group.performance.id, QGroup.group.count())
+            .from(QGroup.group)
+            .where(
+                QGroup.group.performance.id.in(performanceIds),
+                QGroup.group.deleted.isNull()
+            )
+            .groupBy(QGroup.group.performance.id)
+            .fetch();
+
+        Map<Long, Integer> map = performanceIds.stream()
+            .collect(Collectors.toMap(id -> id, count -> 0));
+
+        for (Tuple tuple : result) {
+            Long id = tuple.get(QGroup.group.performance.id);
+            Integer count = tuple.get(QGroup.group.count()).intValue();
+            map.put(id, count);
+        }
+        return map;
     }
 
     private BooleanExpression titleContains(String title) {
-        return title != null && !title.trim().isEmpty() ? 
-                QPerformance.performance.title.containsIgnoreCase(title.trim()) : null;
+        return title != null && !title.trim().isEmpty() ?
+            QPerformance.performance.title.containsIgnoreCase(title.trim()) : null;
     }
 
     private BooleanExpression locationContains(String location) {
-        return location != null && !location.trim().isEmpty() ? 
-                QPerformance.performance.location.containsIgnoreCase(location.trim()) : null;
+        return location != null && !location.trim().isEmpty() ?
+            QPerformance.performance.location.containsIgnoreCase(location.trim()) : null;
     }
 
     private BooleanExpression visitEquals(String visit) {
-        return visit != null && !visit.trim().isEmpty() ? 
-                QPerformance.performance.visit.eq(visit.trim()) : null;
+        return visit != null && !visit.trim().isEmpty() ?
+            QPerformance.performance.visit.eq(visit.trim()) : null;
     }
 
     private BooleanExpression dateRangeFilter(java.time.LocalDate startDate, java.time.LocalDate endDate) {
         QPerformance p = QPerformance.performance;
-        
+
         if (startDate != null && endDate != null) {
             LocalDateTime startDateTime = startDate.atStartOfDay();
             LocalDateTime endDateTime = endDate.atTime(23, 59, 59);
@@ -110,7 +133,7 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
             LocalDateTime endDateTime = endDate.atTime(23, 59, 59);
             return p.endDate.loe(endDateTime);
         }
-        
+
         return null;
     }
 
@@ -120,11 +143,11 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 
     private JPAQuery<Performance> applySorting(JPAQuery<Performance> query, String sort) {
         QPerformance p = QPerformance.performance;
-        
+
         if (sort == null || sort.trim().isEmpty()) {
             sort = "title_asc";
         }
-        
+
         switch (sort.toLowerCase()) {
             case "title_desc":
                 return query.orderBy(p.title.desc());

--- a/src/main/java/site/festifriends/entity/Bookmark.java
+++ b/src/main/java/site/festifriends/entity/Bookmark.java
@@ -2,6 +2,8 @@ package site.festifriends.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,29 +16,35 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.festifriends.common.model.BaseEntity;
+import site.festifriends.entity.enums.BookmarkType;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "performance_bookmark")
-public class PerformanceBookmark extends BaseEntity {
+@Table(name = "bookmark")
+public class Bookmark extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "performance_bookmark_id", nullable = false)
+    @Column(name = "bookmark_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "performance_id", nullable = false)
-    private Performance performance;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private BookmarkType type;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
 
     @Builder
-    public PerformanceBookmark(Member member, Performance performance) {
+    public Bookmark(Member member, BookmarkType type, Long targetId) {
         this.member = member;
-        this.performance = performance;
+        this.type = type;
+        this.targetId = targetId;
     }
+
 }

--- a/src/main/java/site/festifriends/entity/Performance.java
+++ b/src/main/java/site/festifriends/entity/Performance.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -53,12 +54,14 @@ public class Performance extends SoftDeleteEntity {
 
     @ElementCollection
     @CollectionTable(name = "performance_cast", joinColumns = @JoinColumn(name = "performance_id"))
+    @OrderColumn(name = "order_index")
     @Column(name = "cast_member")
     @Comment("공연 출연진")
     private List<String> cast = new ArrayList<>();
 
     @ElementCollection
     @CollectionTable(name = "performance_crew", joinColumns = @JoinColumn(name = "performance_id"))
+    @OrderColumn(name = "order_index")
     @Column(name = "crew_member")
     @Comment("공연 제작진")
     private List<String> crew = new ArrayList<>();
@@ -73,30 +76,35 @@ public class Performance extends SoftDeleteEntity {
 
     @ElementCollection
     @CollectionTable(name = "performance_production_company", joinColumns = @JoinColumn(name = "performance_id"))
+    @OrderColumn(name = "order_index")
     @Column(name = "company")
     @Comment("제작사")
     private List<String> productionCompany = new ArrayList<>();
 
     @ElementCollection
     @CollectionTable(name = "performance_agency", joinColumns = @JoinColumn(name = "performance_id"))
+    @OrderColumn(name = "order_index")
     @Column(name = "agency")
     @Comment("기획사")
     private List<String> agency = new ArrayList<>();
 
     @ElementCollection
     @CollectionTable(name = "performance_host", joinColumns = @JoinColumn(name = "performance_id"))
+    @OrderColumn(name = "order_index")
     @Column(name = "host")
     @Comment("주최")
     private List<String> host = new ArrayList<>();
 
     @ElementCollection
     @CollectionTable(name = "performance_organizer", joinColumns = @JoinColumn(name = "performance_id"))
+    @OrderColumn(name = "order_index")
     @Column(name = "organizer")
     @Comment("주관")
     private List<String> organizer = new ArrayList<>();
 
     @ElementCollection
     @CollectionTable(name = "performance_price", joinColumns = @JoinColumn(name = "performance_id"))
+    @OrderColumn(name = "order_index")
     @Column(name = "price")
     @Comment("티켓 가격")
     private List<String> price = new ArrayList<>();
@@ -116,6 +124,7 @@ public class Performance extends SoftDeleteEntity {
 
     @ElementCollection
     @CollectionTable(name = "performance_time", joinColumns = @JoinColumn(name = "performance_id"))
+    @OrderColumn(name = "order_index")
     @Column(name = "time")
     @Comment("공연 시간")
     private List<LocalDateTime> time = new ArrayList<>();

--- a/src/main/java/site/festifriends/entity/enums/BookmarkType.java
+++ b/src/main/java/site/festifriends/entity/enums/BookmarkType.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum BookmarkType {
-    USER("회원"),
+    MEMBER("회원"),
     PERFORMANCE("공연");
 
     private final String type;

--- a/src/main/java/site/festifriends/entity/enums/BookmarkType.java
+++ b/src/main/java/site/festifriends/entity/enums/BookmarkType.java
@@ -1,0 +1,16 @@
+package site.festifriends.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 북마크 타입을 나타내는 Enum
+ */
+@Getter
+@AllArgsConstructor
+public enum BookmarkType {
+    USER("회원"),
+    PERFORMANCE("공연");
+
+    private final String type;
+}

--- a/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,113 @@
+package site.festifriends.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import site.festifriends.common.config.AuditConfig;
+import site.festifriends.common.config.QueryDslConfig;
+import site.festifriends.domain.member.dto.LikedMemberDto;
+import site.festifriends.entity.Bookmark;
+import site.festifriends.entity.Member;
+import site.festifriends.entity.enums.BookmarkType;
+import site.festifriends.entity.enums.Gender;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, AuditConfig.class})
+@ActiveProfiles("test")
+public class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepositoryImpl memberRepositoryImpl; // 혹은 MemberRepositoryCustom
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+
+    @Test
+    @DisplayName("내가 찜한 사용자 목록을 커서 기반으로 조회한다")
+    void getMyLikedMembers_test() {
+        // given
+        Member member = memberRepository.save(Member.builder()
+            .email("test1@example.com")
+            .nickname("테스트")
+            .profileImageUrl("https://example.com/profiles/test1.jpg")
+            .age(28)
+            .gender(Gender.MALE)
+            .introduction("안녕하세요.")
+            .tags(List.of("음악", "여행"))
+            .socialId("socialId1")
+            .build());
+
+        Member target1 = memberRepository.save(Member.builder()
+            .email("test2@example.com")
+            .nickname("테스트2")
+            .profileImageUrl("https://example.com/profiles/test2.jpg")
+            .age(20)
+            .gender(Gender.MALE)
+            .introduction("안녕하세요.")
+            .tags(List.of("음악", "여행"))
+            .socialId("socialId2")
+            .build());
+
+        Member target2 = memberRepository.save(Member.builder()
+            .email("test3@example.com")
+            .nickname("테스트3")
+            .profileImageUrl("https://example.com/profiles/test3.jpg")
+            .age(21)
+            .gender(Gender.MALE)
+            .introduction("안녕하세요.")
+            .tags(List.of("음악", "여행"))
+            .socialId("socialId3")
+            .build());
+
+        bookmarkRepository.save(
+            Bookmark.builder()
+                .member(member)
+                .type(BookmarkType.MEMBER)
+                .targetId(target1.getId())
+                .build()
+        );
+
+        bookmarkRepository.save(
+            Bookmark.builder()
+                .member(member)
+                .type(BookmarkType.MEMBER)
+                .targetId(target2.getId())
+                .build()
+        );
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Slice<LikedMemberDto> result = memberRepositoryImpl.getMyLikedMembers(member.getId(), null, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.hasNext()).isFalse();
+        List<LikedMemberDto> content = result.getContent();
+        assertThat(content).isNotEmpty();
+
+        LikedMemberDto dto1 = content.get(0);
+        assertThat(dto1.getName()).isEqualTo("테스트3");
+        assertThat(dto1.getGender()).isEqualTo("MALE");
+        assertThat(dto1.getAge()).isEqualTo(21);
+        assertThat(dto1.getProfileImage()).isEqualTo("https://example.com/profiles/test3.jpg");
+
+        LikedMemberDto dto2 = content.get(1);
+        assertThat(dto2.getName()).isEqualTo("테스트2");
+        assertThat(dto2.getGender()).isEqualTo("MALE");
+        assertThat(dto2.getAge()).isEqualTo(20);
+        assertThat(dto2.getProfileImage()).isEqualTo("https://example.com/profiles/test2.jpg");
+    }
+}

--- a/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package site.festifriends.domain.member.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,10 +16,16 @@ import org.springframework.test.context.ActiveProfiles;
 import site.festifriends.common.config.AuditConfig;
 import site.festifriends.common.config.QueryDslConfig;
 import site.festifriends.domain.member.dto.LikedMemberDto;
+import site.festifriends.domain.member.dto.LikedPerformanceDto;
+import site.festifriends.domain.performance.repository.PerformanceImageRepository;
+import site.festifriends.domain.performance.repository.PerformanceRepository;
 import site.festifriends.entity.Bookmark;
 import site.festifriends.entity.Member;
+import site.festifriends.entity.Performance;
+import site.festifriends.entity.PerformanceImage;
 import site.festifriends.entity.enums.BookmarkType;
 import site.festifriends.entity.enums.Gender;
+import site.festifriends.entity.enums.PerformanceState;
 
 @DataJpaTest
 @Import({QueryDslConfig.class, AuditConfig.class})
@@ -33,6 +40,12 @@ public class MemberRepositoryTest {
 
     @Autowired
     private BookmarkRepository bookmarkRepository;
+
+    @Autowired
+    private PerformanceRepository performanceRepository;
+
+    @Autowired
+    private PerformanceImageRepository performanceImageRepository;
 
     @Test
     @DisplayName("[성공] 내가 찜한 사용자 목록 조회")
@@ -169,5 +182,96 @@ public class MemberRepositoryTest {
 
         // then
         assertThat(count).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("[성공] 내가 찜한 공연 목록 조회")
+    void getMyLikedPerformances_test() {
+        // given
+        Member member = memberRepository.save(Member.builder()
+            .email("test1@example.com")
+            .nickname("테스터")
+            .profileImageUrl("https://example.com/profile.jpg")
+            .age(28)
+            .gender(Gender.MALE)
+            .introduction("소개")
+            .socialId("social1")
+            .build());
+
+        Performance performance = performanceRepository.save(Performance.builder()
+            .title("테스트 공연")
+            .startDate(LocalDateTime.of(2025, 5, 30, 18, 0))
+            .endDate(LocalDateTime.of(2025, 6, 1, 22, 0))
+            .location("올림픽공원")
+            .cast(List.of("배우1", "배우2"))
+            .crew(List.of("감독1", "작가1"))
+            .runtime("180분")
+            .age("만 12세 이상")
+            .productionCompany(List.of("제작사1"))
+            .agency(List.of("기획사1"))
+            .host(List.of("주최1"))
+            .organizer(List.of("주관사1"))
+            .price(List.of("VIP 10만원", "R석 8만원", "S석 5만원"))
+            .poster("https://example.com/poster.jpg")
+            .state(PerformanceState.UPCOMING)
+            .visit("국내")
+            .time(List.of(
+                LocalDateTime.of(2025, 5, 30, 18, 0),
+                LocalDateTime.of(2025, 5, 31, 19, 0),
+                LocalDateTime.of(2025, 6, 1, 20, 0)
+            ))
+            .build());
+
+        PerformanceImage pr1 = new PerformanceImage(performance, "https://example.com/img1.jpg", "이미지1");
+        PerformanceImage pr2 = new PerformanceImage(performance, "https://example.com/img2.jpg", "이미지2");
+        performanceImageRepository.save(pr1);
+        performanceImageRepository.save(pr2);
+
+        bookmarkRepository.save(
+            Bookmark.builder()
+                .member(member)
+                .type(BookmarkType.PERFORMANCE)
+                .targetId(performance.getId())
+                .build()
+        );
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Slice<LikedPerformanceDto> result = memberRepositoryImpl.getMyLikedPerformances(member.getId(), null, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.hasNext()).isFalse();
+        List<LikedPerformanceDto> content = result.getContent();
+        assertThat(content).isNotEmpty();
+        LikedPerformanceDto dto = content.get(0);
+        assertThat(dto.getId()).isEqualTo(performance.getId());
+        assertThat(dto.getTitle()).isEqualTo("테스트 공연");
+        assertThat(dto.getStartDate()).isEqualTo(LocalDateTime.of(2025, 5, 30, 18, 0));
+        assertThat(dto.getEndDate()).isEqualTo(LocalDateTime.of(2025, 6, 1, 22, 0));
+        assertThat(dto.getLocation()).isEqualTo("올림픽공원");
+        assertThat(dto.getCast()).containsExactly("배우1", "배우2");
+        assertThat(dto.getCrew()).containsExactly("감독1", "작가1");
+        assertThat(dto.getRuntime()).isEqualTo("180분");
+        assertThat(dto.getAge()).isEqualTo("만 12세 이상");
+        assertThat(dto.getProductionCompany()).containsExactly("제작사1");
+        assertThat(dto.getAgency()).containsExactly("기획사1");
+        assertThat(dto.getHost()).containsExactly("주최1");
+        assertThat(dto.getOrganizer()).containsExactly("주관사1");
+        assertThat(dto.getPrice()).containsExactly("VIP 10만원", "R석 8만원", "S석 5만원");
+        assertThat(dto.getPoster()).isEqualTo("https://example.com/poster.jpg");
+        assertThat(dto.getState()).isEqualTo("UPCOMING");
+        assertThat(dto.getVisit()).isEqualTo("국내");
+        assertThat(dto.getImages()).hasSize(2);
+        assertThat(dto.getImages().get(0).getSrc()).isEqualTo("https://example.com/img1.jpg");
+        assertThat(dto.getImages().get(1).getSrc()).isEqualTo("https://example.com/img2.jpg");
+        assertThat(dto.getTime()).containsExactly(
+            LocalDateTime.of(2025, 5, 30, 18, 0),
+            LocalDateTime.of(2025, 5, 31, 19, 0),
+            LocalDateTime.of(2025, 6, 1, 20, 0)
+        );
+        assertThat(dto.getBookmarkId()).isNotNull();
+
     }
 }

--- a/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
@@ -35,7 +35,7 @@ public class MemberRepositoryTest {
     private BookmarkRepository bookmarkRepository;
 
     @Test
-    @DisplayName("내가 찜한 사용자 목록을 커서 기반으로 조회한다")
+    @DisplayName("[성공] 내가 찜한 사용자 목록 조회")
     void getMyLikedMembers_test() {
         // given
         Member member = memberRepository.save(Member.builder()
@@ -109,5 +109,65 @@ public class MemberRepositoryTest {
         assertThat(dto2.getGender()).isEqualTo("MALE");
         assertThat(dto2.getAge()).isEqualTo(20);
         assertThat(dto2.getProfileImage()).isEqualTo("https://example.com/profiles/test2.jpg");
+    }
+
+    @Test
+    @DisplayName("[성공] 내가 찜한 사용자 수 조회")
+    void getMyLikedMembersCount_test() {
+        // given
+        Member member = memberRepository.save(Member.builder()
+            .email("test1@example.com")
+            .nickname("테스트")
+            .profileImageUrl("https://example.com/profiles/test1.jpg")
+            .age(28)
+            .gender(Gender.MALE)
+            .introduction("안녕하세요.")
+            .tags(List.of("음악", "여행"))
+            .socialId("socialId1")
+            .build());
+
+        Member target1 = memberRepository.save(Member.builder()
+            .email("test2@example.com")
+            .nickname("테스트2")
+            .profileImageUrl("https://example.com/profiles/test2.jpg")
+            .age(20)
+            .gender(Gender.MALE)
+            .introduction("안녕하세요.")
+            .tags(List.of("음악", "여행"))
+            .socialId("socialId2")
+            .build());
+
+        Member target2 = memberRepository.save(Member.builder()
+            .email("test3@example.com")
+            .nickname("테스트3")
+            .profileImageUrl("https://example.com/profiles/test3.jpg")
+            .age(21)
+            .gender(Gender.MALE)
+            .introduction("안녕하세요.")
+            .tags(List.of("음악", "여행"))
+            .socialId("socialId3")
+            .build());
+
+        bookmarkRepository.save(
+            Bookmark.builder()
+                .member(member)
+                .type(BookmarkType.MEMBER)
+                .targetId(target1.getId())
+                .build()
+        );
+
+        bookmarkRepository.save(
+            Bookmark.builder()
+                .member(member)
+                .type(BookmarkType.MEMBER)
+                .targetId(target2.getId())
+                .build()
+        );
+
+        // when
+        Long count = memberRepositoryImpl.countMyLikedMembers(member.getId());
+
+        // then
+        assertThat(count).isEqualTo(2L);
     }
 }

--- a/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,91 @@
+package site.festifriends.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.member.dto.LikedMemberDto;
+import site.festifriends.domain.member.dto.MemberDto;
+import site.festifriends.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("[성공] 내가 찜한 유저 목록 조회(nextCursor 존재)")
+    void getMyLikedMembers_cursor_paging() {
+        // given
+        Long memberId = 1L;
+        Long cursorId = null;
+        int size = 2;
+
+        LikedMemberDto member1 = new LikedMemberDto(
+            "테스트1", "Male", 28, "1L", false, "https://example.com/1.jpg", List.of("#음악", "#여행"), 100L);
+        LikedMemberDto member2 = new LikedMemberDto(
+            "테스트2", "Female", 25, "2L", false, "https://example.com/2.jpg", List.of("#운동", "#독서"), 99L);
+        LikedMemberDto member3 = new LikedMemberDto(
+            "테스트3", "Male", 30, "3L", false, "https://example.com/3.jpg", List.of("#사진"), 98L);
+
+        List<LikedMemberDto> memberList = Arrays.asList(member1, member2, member3);
+        Slice<LikedMemberDto> slice = new SliceImpl<>(memberList, PageRequest.of(0, size + 1), true);
+
+        when(memberRepository.getMyLikedMembers(eq(memberId), eq(cursorId), any(PageRequest.class)))
+            .thenReturn(slice);
+
+        // when
+        CursorResponseWrapper<MemberDto> response = memberService.getMyLikedMembers(memberId, cursorId, size);
+
+        // then
+        assertThat(response.getData()).hasSize(size);
+        assertThat(response.getData().get(0).getName()).isEqualTo("테스트1");
+        assertThat(response.getHasNext()).isTrue();
+        assertThat(response.getCursorId()).isEqualTo(98L);
+    }
+
+    @Test
+    @DisplayName("[성공] 내가 찜한 유저 목록 조회(nextCursor 없을 때)")
+    void getMyLikedMembers_noMoreData() {
+        // given
+        Long memberId = 1L;
+        Long cursorId = null;
+        int size = 2;
+
+        LikedMemberDto member1 = new LikedMemberDto(
+            "테스트1", "Male", 28, "1L", false, "https://example.com/1.jpg", List.of("#음악", "#여행"), 100L);
+        LikedMemberDto member2 = new LikedMemberDto(
+            "테스트2", "Female", 25, "2L", false, "https://example.com/2.jpg", List.of("#운동", "#독서"), 99L);
+
+        List<LikedMemberDto> memberList = Arrays.asList(member1, member2);
+        Slice<LikedMemberDto> slice = new SliceImpl<>(memberList, PageRequest.of(0, size + 1), false);
+
+        when(memberRepository.getMyLikedMembers(eq(memberId), eq(cursorId), any(PageRequest.class)))
+            .thenReturn(slice);
+
+        // when
+        CursorResponseWrapper<MemberDto> response = memberService.getMyLikedMembers(memberId, cursorId, size);
+
+        // then
+        assertThat(response.getData()).hasSize(2);
+        assertThat(response.getHasNext()).isFalse();
+        assertThat(response.getCursorId()).isNull();
+    }
+}

--- a/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +19,10 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.domain.member.dto.LikedMemberDto;
-import site.festifriends.domain.member.dto.MemberDto;
+import site.festifriends.domain.member.dto.LikedMemberResponse;
+import site.festifriends.domain.member.dto.LikedPerformanceDto;
+import site.festifriends.domain.member.dto.LikedPerformanceImageDto;
+import site.festifriends.domain.member.dto.LikedPerformanceResponse;
 import site.festifriends.domain.member.repository.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,7 +56,7 @@ class MemberServiceTest {
             .thenReturn(slice);
 
         // when
-        CursorResponseWrapper<MemberDto> response = memberService.getMyLikedMembers(memberId, cursorId, size);
+        CursorResponseWrapper<LikedMemberResponse> response = memberService.getMyLikedMembers(memberId, cursorId, size);
 
         // then
         assertThat(response.getData()).hasSize(size);
@@ -81,11 +85,83 @@ class MemberServiceTest {
             .thenReturn(slice);
 
         // when
-        CursorResponseWrapper<MemberDto> response = memberService.getMyLikedMembers(memberId, cursorId, size);
+        CursorResponseWrapper<LikedMemberResponse> response = memberService.getMyLikedMembers(memberId, cursorId, size);
 
         // then
         assertThat(response.getData()).hasSize(2);
         assertThat(response.getHasNext()).isFalse();
         assertThat(response.getCursorId()).isNull();
     }
+
+    @Test
+    @DisplayName("[성공] 내가 찜한 공연 목록 조회")
+    void getMyLikedPerformances() {
+        // given
+        Long memberId = 1L;
+        Long cursorId = null;
+        int size = 1;
+
+        LikedPerformanceDto performance1 = new LikedPerformanceDto(
+            1L,
+            "공연1",
+            LocalDateTime.of(2023, 10, 1, 0, 0),
+            LocalDateTime.of(2023, 10, 2, 0, 0),
+            "장소1",
+            List.of("배우1", "배우2"),
+            List.of("스태프1"),
+            "180분",
+            "만 12세 이상",
+            List.of("제작사1"),
+            List.of("기획사1"),
+            List.of("주최1"),
+            List.of("주관1"),
+            List.of("VIP 10만원"),
+            "https://example.com/performance1.jpg",
+            "UPCOMING",
+            "국내",
+            List.of(new LikedPerformanceImageDto("1", "https://example.com/img1.jpg", "이미지1")),
+            List.of(LocalDateTime.of(2023, 10, 1, 18, 0)),
+            100L // bookmarkId
+        );
+
+        LikedPerformanceDto performance2 = new LikedPerformanceDto(
+            2L,
+            "공연2",
+            LocalDateTime.of(2023, 11, 1, 0, 0),
+            LocalDateTime.of(2023, 11, 2, 0, 0),
+            "장소2",
+            List.of("배우3", "배우4"),
+            List.of("스태프2"),
+            "180분",
+            "만 12세 이상",
+            List.of("제작사2"),
+            List.of("기획사2"),
+            List.of("주최2"),
+            List.of("주관2"),
+            List.of("VIP 9만원"),
+            "https://example.com/performance2.jpg",
+            "UPCOMING",
+            "국내",
+            List.of(new LikedPerformanceImageDto("2", "https://example.com/img2.jpg", "이미지2")),
+            List.of(LocalDateTime.of(2023, 11, 1, 18, 0)),
+            101L // bookmarkId
+        );
+
+        List<LikedPerformanceDto> performanceList = Arrays.asList(performance1, performance2);
+        Slice<LikedPerformanceDto> slice = new SliceImpl<>(performanceList, PageRequest.of(0, size + 1), true);
+
+        when(memberRepository.getMyLikedPerformances(eq(memberId), eq(cursorId), any(PageRequest.class)))
+            .thenReturn(slice);
+
+        // when
+        CursorResponseWrapper<LikedPerformanceResponse> response =
+            memberService.getMyLikedPerformances(memberId, cursorId, size);
+
+        // then
+        assertThat(response.getData()).hasSize(size);
+        assertThat(response.getData().get(0).getTitle()).isEqualTo("공연1");
+        assertThat(response.getHasNext()).isTrue();
+        assertThat(response.getCursorId()).isEqualTo(101L);
+    }
+
 }

--- a/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
@@ -24,12 +24,16 @@ import site.festifriends.domain.member.dto.LikedPerformanceDto;
 import site.festifriends.domain.member.dto.LikedPerformanceImageDto;
 import site.festifriends.domain.member.dto.LikedPerformanceResponse;
 import site.festifriends.domain.member.repository.MemberRepository;
+import site.festifriends.domain.performance.repository.PerformanceRepository;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private PerformanceRepository performanceRepository;
 
     @InjectMocks
     private MemberService memberService;
@@ -162,6 +166,7 @@ class MemberServiceTest {
         assertThat(response.getData().get(0).getTitle()).isEqualTo("공연1");
         assertThat(response.getHasNext()).isTrue();
         assertThat(response.getCursorId()).isEqualTo(101L);
+        assertThat(response.getData().get(0).getGroupCount()).isEqualTo(0);
     }
 
 }


### PR DESCRIPTION
## 작업 내용
- [🚑fix: 회원탈퇴 api 구현체 @AuthenticationPrincipal 적용](https://github.com/FestiFriends/ff_backend/commit/f2d5d457f44bf2953295e1ff9b79ea8fe713ec88)
  -  회원 탈퇴 api 의 파라미터에 `@AuthenticationPrincipal` 을 적용하였습니다.
- [✨feat: PerformanceBookmark -> Bookmark 엔티티로 변경 및 타입 추가](https://github.com/FestiFriends/ff_backend/commit/deb8e9032a1bae8776aca66c21acf66f3c9a0171)
  - 공연 뿐만 아닌 유저 위시리스트 목록도 추가하기 위해, enum 클래스 및 테이블명을 변경하였습니다.
- [✨feat: 모입 가입 신청취소 및 확정안함 기능 작성](https://github.com/FestiFriends/ff_backend/commit/781c4e4c48afe8dba7ccbb33812ccb66e169cd5d) 
- [✨feat: 내가 찜한 사용자 목록 조회 작성](https://github.com/FestiFriends/ff_backend/commit/9055487d808784767c28358a89eba222ebace5c3)
- [✨feat: 내가 찜한 유저 수 조회 기능 작성](https://github.com/FestiFriends/ff_backend/commit/93c6c93c180e1ebfbcc47794a097e678c305c3d2)
- [✨feat: CollectionTable 순서 보장을 위해 OrderColumn 어노테이션 추가](https://github.com/FestiFriends/ff_backend/commit/19c2f11b74838f76afbd7310ea51873eed0de40b)
  - api 응답에서 가격, 시간 등 응답의 순서를 보장하기 위해 `@OrderColumn` 을 추가하였습니다.
- [✨feat: 내가 찜한 공연 목록 api 작성](https://github.com/FestiFriends/ff_backend/commit/f3184f8ba1316f274ef8d4d7ac4efdbe1a477b95)