### PR TITLE
✨feat: 게시글 고정/취소 기능 추가

### DIFF
--- a/src/main/java/site/festifriends/domain/application/controller/ApplicationApi.java
+++ b/src/main/java/site/festifriends/domain/application/controller/ApplicationApi.java
@@ -75,17 +75,17 @@ public interface ApplicationApi {
 
     @Operation(
         summary = "모임 신청서 수락/거절",
-        description = "방장이 모임 가입 신청을 수락하거나 거절합니다.",
+        description = "방장이 모임 가입 신청을 수락하거나 거절합니다. 요청 시 status는 'ACCEPTED' 또는 'REJECTED'만 허용됩니다.",
         responses = {
             @ApiResponse(responseCode = "200", description = "모임 신청서 처리 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (상태값이 ACCEPTED 또는 REJECTED가 아님)"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "403", description = "권한이 없는 사용자 (방장만 가능)"),
             @ApiResponse(responseCode = "404", description = "신청서를 찾을 수 없음"),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
         }
     )
-    ResponseEntity<ResponseWrapper<ApplicationStatusResponse>> updateApplicationStatus(
+    ResponseEntity<ResponseWrapper<Void>> updateApplicationStatus(
         @AuthenticationPrincipal UserDetailsImpl user,
         @Parameter(description = "신청서 ID")
         @PathVariable Long applicationId,

--- a/src/main/java/site/festifriends/domain/application/controller/ApplicationApi.java
+++ b/src/main/java/site/festifriends/domain/application/controller/ApplicationApi.java
@@ -94,19 +94,20 @@ public interface ApplicationApi {
 
     @Operation(
         summary = "모임 가입 확정",
-        description = "신청자가 수락된 모임 가입을 확정합니다.",
+        description = "신청자가 수락된 모임 가입을 확정합니다. 요청 시 status는 'CONFIRMED'만 허용됩니다.",
         responses = {
             @ApiResponse(responseCode = "200", description = "모임 가입 확정 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (상태값이 CONFIRMED가 아님)"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "403", description = "권한이 없는 사용자 (신청자만 가능)"),
             @ApiResponse(responseCode = "404", description = "신청서를 찾을 수 없음"),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
         }
     )
-    ResponseEntity<ResponseWrapper<ApplicationStatusResponse>> confirmApplication(
+    ResponseEntity<ResponseWrapper<Void>> confirmApplication(
         @AuthenticationPrincipal UserDetailsImpl user,
         @Parameter(description = "신청서 ID")
-        @PathVariable Long applicationId
+        @PathVariable Long applicationId,
+        @RequestBody ApplicationStatusRequest request
     );
 } 

--- a/src/main/java/site/festifriends/domain/application/controller/ApplicationController.java
+++ b/src/main/java/site/festifriends/domain/application/controller/ApplicationController.java
@@ -81,12 +81,13 @@ public class ApplicationController implements ApplicationApi {
 
     @Override
     @PatchMapping("/applied/{applicationId}")
-    public ResponseEntity<ResponseWrapper<ApplicationStatusResponse>> confirmApplication(
+    public ResponseEntity<ResponseWrapper<Void>> confirmApplication(
         @AuthenticationPrincipal UserDetailsImpl user,
-        @PathVariable Long applicationId
+        @PathVariable Long applicationId,
+        @RequestBody ApplicationStatusRequest request
     ) {
-        ResponseWrapper<ApplicationStatusResponse> response =
-            applicationService.confirmApplication(user.getMemberId(), applicationId);
+        ResponseWrapper<Void> response =
+            applicationService.confirmApplication(user.getMemberId(), applicationId, request);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/site/festifriends/domain/application/controller/ApplicationController.java
+++ b/src/main/java/site/festifriends/domain/application/controller/ApplicationController.java
@@ -68,12 +68,12 @@ public class ApplicationController implements ApplicationApi {
 
     @Override
     @PatchMapping("/{applicationId}")
-    public ResponseEntity<ResponseWrapper<ApplicationStatusResponse>> updateApplicationStatus(
+    public ResponseEntity<ResponseWrapper<Void>> updateApplicationStatus(
         @AuthenticationPrincipal UserDetailsImpl user,
         @PathVariable Long applicationId,
         @RequestBody ApplicationStatusRequest request
     ) {
-        ResponseWrapper<ApplicationStatusResponse> response =
+        ResponseWrapper<Void> response =
             applicationService.updateApplicationStatus(user.getMemberId(), applicationId, request);
 
         return ResponseEntity.ok(response);

--- a/src/main/java/site/festifriends/domain/application/dto/ApplicationStatusRequest.java
+++ b/src/main/java/site/festifriends/domain/application/dto/ApplicationStatusRequest.java
@@ -1,12 +1,23 @@
 package site.festifriends.domain.application.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import site.festifriends.entity.enums.ApplicationStatus;
 
 @Getter
 @Setter
 @NoArgsConstructor
+@Schema(description = "모임 신청서 상태 변경 요청")
 public class ApplicationStatusRequest {
-    private String status;
-} 
+    
+    @NotNull(message = "상태는 필수입니다.")
+    @Schema(
+        description = "신청서 상태 (모임 방장이 수락하면 ACCEPTED, 거절하면 REJECTED)", 
+        example = "ACCEPTED",
+        allowableValues = {"ACCEPTED", "REJECTED"}
+    )
+    private ApplicationStatus status;
+}

--- a/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
+++ b/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
@@ -300,7 +300,7 @@ public class ApplicationService {
      * 모임 신청서 수락/거절
      */
     @Transactional
-    public ResponseWrapper<ApplicationStatusResponse> updateApplicationStatus(
+    public ResponseWrapper<Void> updateApplicationStatus(
         Long hostId,
         Long applicationId,
         ApplicationStatusRequest request
@@ -314,24 +314,20 @@ public class ApplicationService {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "처리할 수 없는 신청서 상태입니다.");
         }
 
-        String status = request.getStatus();
+        ApplicationStatus status = request.getStatus();
         String message;
 
-        if ("accept".equals(status)) {
+        if (status == ApplicationStatus.ACCEPTED) {
             application.approve();
             message = "모임 가입 신청을 수락하였습니다";
-        } else if ("reject".equals(status)) {
+        } else if (status == ApplicationStatus.REJECTED) {
             application.reject();
             message = "모임 가입 신청을 거절하였습니다";
         } else {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, "잘못된 상태 값입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "잘못된 상태 값입니다. ACCEPTED 또는 REJECTED만 허용됩니다.");
         }
 
-        ApplicationStatusResponse response = ApplicationStatusResponse.builder()
-            .result(true)
-            .build();
-
-        return ResponseWrapper.success(message, response);
+        return ResponseWrapper.success(message, null);
     }
 
     /**

--- a/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
+++ b/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
@@ -334,9 +334,10 @@ public class ApplicationService {
      * 모임 가입 확정
      */
     @Transactional
-    public ResponseWrapper<ApplicationStatusResponse> confirmApplication(
+    public ResponseWrapper<Void> confirmApplication(
         Long memberId,
-        Long applicationId
+        Long applicationId,
+        ApplicationStatusRequest request
     ) {
         MemberGroup application = applicationRepository.findById(applicationId)
             .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "신청서를 찾을 수 없습니다."));
@@ -347,13 +348,14 @@ public class ApplicationService {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "수락된 신청서만 확정할 수 있습니다.");
         }
 
+        ApplicationStatus status = request.getStatus();
+        if (status != ApplicationStatus.CONFIRMED) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "잘못된 상태 값입니다. CONFIRMED만 허용됩니다.");
+        }
+
         application.confirm();
 
-        ApplicationStatusResponse response = ApplicationStatusResponse.builder()
-            .result(true)
-            .build();
-
-        return ResponseWrapper.success("모임 가입을 확정하였습니다", response);
+        return ResponseWrapper.success("모임 가입을 확정하였습니다", null);
     }
 
     private void validateHostPermission(Long hostId, MemberGroup application) {

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.performance.dto.PerformanceResponse;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.domain.performance.dto.PerformanceSearchResponse;
@@ -45,7 +46,7 @@ public interface PerformanceApi {
             description = "공연 ID로 공연 상세 정보를 조회합니다."
     )
     @GetMapping("/{performanceId}")
-    ResponseEntity<PerformanceResponse> getPerformanceDetail(
+    ResponseEntity<ResponseWrapper<PerformanceResponse>> getPerformanceDetail(
             @Parameter(description = "공연 ID") @PathVariable Long performanceId
     );
 }

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.performance.dto.PerformanceResponse;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.domain.performance.dto.PerformanceSearchResponse;
@@ -28,8 +29,8 @@ public class PerformanceController implements PerformanceApi {
 
     @Override
     @GetMapping("/{performanceId}")
-    public ResponseEntity<PerformanceResponse> getPerformanceDetail(@PathVariable Long performanceId) {
-        PerformanceResponse response = performanceService.getPerformanceDetail(performanceId);
+    public ResponseEntity<ResponseWrapper<PerformanceResponse>> getPerformanceDetail(@PathVariable Long performanceId) {
+        ResponseWrapper<PerformanceResponse> response = performanceService.getPerformanceDetail(performanceId);
         return ResponseEntity.ok(response);
     }
 } 

--- a/src/main/java/site/festifriends/domain/performance/dto/PerformanceResponse.java
+++ b/src/main/java/site/festifriends/domain/performance/dto/PerformanceResponse.java
@@ -29,6 +29,7 @@ public class PerformanceResponse {
     private List<PerformanceImage> images; // 소개 이미지 목록
     private List<String> time;       // 공연 시간 (ISO 8601) 배열
     private Integer groupCount;      // 모임 개수 (모임개수 정렬용)
+    private Integer favoriteCount;   // 공연 찜 수
     
     @Getter
     @Builder

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface PerformanceRepositoryCustom {
     Page<Performance> searchPerformancesWithPaging(PerformanceSearchRequest request, Pageable pageable);
     
     Map<Long, Long> findGroupCountsByPerformanceIds(List<Long> performanceIds);
+    
+    Map<Long, Long> findFavoriteCountsByPerformanceIds(List<Long> performanceIds);
 } 

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryImpl.java
@@ -12,6 +12,7 @@ import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.entity.Performance;
 import site.festifriends.entity.QGroup;
 import site.festifriends.entity.QPerformance;
+import site.festifriends.entity.QPerformanceBookmark;
 import site.festifriends.entity.QPerformanceImage;
 
 import java.time.LocalDateTime;
@@ -72,6 +73,27 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
                 .fetch()
                 .stream()
                 .map(tuple -> new Object[]{tuple.get(g.performance.id), tuple.get(g.count())})
+                .collect(Collectors.toList());
+
+        return results.stream()
+                .collect(Collectors.toMap(
+                        result -> (Long) result[0],
+                        result -> (Long) result[1]
+                ));
+    }
+
+    @Override
+    public Map<Long, Long> findFavoriteCountsByPerformanceIds(List<Long> performanceIds) {
+        QPerformanceBookmark pb = QPerformanceBookmark.performanceBookmark;
+
+        List<Object[]> results = queryFactory
+                .select(pb.performance.id, pb.count())
+                .from(pb)
+                .where(pb.performance.id.in(performanceIds))
+                .groupBy(pb.performance.id)
+                .fetch()
+                .stream()
+                .map(tuple -> new Object[]{tuple.get(pb.performance.id), tuple.get(pb.count())})
                 .collect(Collectors.toList());
 
         return results.stream()

--- a/src/main/java/site/festifriends/domain/performance/service/PerformanceService.java
+++ b/src/main/java/site/festifriends/domain/performance/service/PerformanceService.java
@@ -44,6 +44,9 @@ public class PerformanceService {
 
         // 각 공연별 모임 개수 조회
         Map<Long, Long> groupCountMap = performanceRepository.findGroupCountsByPerformanceIds(performanceIds);
+        
+        // 각 공연별 찜 개수 조회
+        Map<Long, Long> favoriteCountMap = performanceRepository.findFavoriteCountsByPerformanceIds(performanceIds);
 
         performances.forEach(performance -> {
             performance.getCast().size();
@@ -58,7 +61,7 @@ public class PerformanceService {
         });
 
         List<PerformanceResponse> performanceResponses = performances.stream()
-                .map(performance -> convertToResponse(performance, groupCountMap))
+                .map(performance -> convertToResponse(performance, groupCountMap, favoriteCountMap))
                 .collect(Collectors.toList());
 
         if ("group_count_desc".equals(request.getSort())) {
@@ -112,11 +115,15 @@ public class PerformanceService {
         // 해당 공연의 모임 개수 조회
         Map<Long, Long> groupCountMap = performanceRepository.findGroupCountsByPerformanceIds(
                 Collections.singletonList(performanceId));
+        
+        // 해당 공연의 찜 개수 조회
+        Map<Long, Long> favoriteCountMap = performanceRepository.findFavoriteCountsByPerformanceIds(
+                Collections.singletonList(performanceId));
 
-        return convertToResponse(performance, groupCountMap);
+        return convertToResponse(performance, groupCountMap, favoriteCountMap);
     }
 
-    private PerformanceResponse convertToResponse(Performance performance, Map<Long, Long> groupCountMap) {
+    private PerformanceResponse convertToResponse(Performance performance, Map<Long, Long> groupCountMap, Map<Long, Long> favoriteCountMap) {
         List<PerformanceResponse.PerformanceImage> images = performance.getImgs().stream()
                 .map(img -> PerformanceResponse.PerformanceImage.builder()
                         .id(img.getId().toString())
@@ -150,6 +157,7 @@ public class PerformanceService {
                 .images(images)
                 .time(timeStrings)
                 .groupCount(groupCountMap.getOrDefault(performance.getId(), 0L).intValue())
+                .favoriteCount(favoriteCountMap.getOrDefault(performance.getId(), 0L).intValue())
                 .build();
     }
 } 

--- a/src/main/java/site/festifriends/domain/performance/service/PerformanceService.java
+++ b/src/main/java/site/festifriends/domain/performance/service/PerformanceService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.festifriends.common.exception.BusinessException;
 import site.festifriends.common.exception.ErrorCode;
+import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.performance.dto.PerformanceResponse;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.domain.performance.dto.PerformanceSearchResponse;
@@ -98,7 +99,7 @@ public class PerformanceService {
     /**
      * 공연 상세 정보 조회
      */
-    public PerformanceResponse getPerformanceDetail(Long performanceId) {
+    public ResponseWrapper<PerformanceResponse> getPerformanceDetail(Long performanceId) {
         Performance performance = performanceRepository.findById(performanceId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "공연을 찾을 수 없습니다."));
 
@@ -120,7 +121,9 @@ public class PerformanceService {
         Map<Long, Long> favoriteCountMap = performanceRepository.findFavoriteCountsByPerformanceIds(
                 Collections.singletonList(performanceId));
 
-        return convertToResponse(performance, groupCountMap, favoriteCountMap);
+        PerformanceResponse response = convertToResponse(performance, groupCountMap, favoriteCountMap);
+        
+        return ResponseWrapper.success("요청이 성공적으로 처리되었습니다.", response);
     }
 
     private PerformanceResponse convertToResponse(Performance performance, Map<Long, Long> groupCountMap, Map<Long, Long> favoriteCountMap) {
@@ -130,10 +133,6 @@ public class PerformanceService {
                         .src(img.getSrc())
                         .alt(img.getAlt())
                         .build())
-                .collect(Collectors.toList());
-
-        List<String> timeStrings = performance.getTime().stream()
-                .map(time -> time.format(ISO_FORMATTER))
                 .collect(Collectors.toList());
 
         return PerformanceResponse.builder()
@@ -155,7 +154,7 @@ public class PerformanceService {
                 .state(performance.getState().getDescription())
                 .visit(performance.getVisit())
                 .images(images)
-                .time(timeStrings)
+                .time(performance.getTime())
                 .groupCount(groupCountMap.getOrDefault(performance.getId(), 0L).intValue())
                 .favoriteCount(favoriteCountMap.getOrDefault(performance.getId(), 0L).intValue())
                 .build();

--- a/src/main/java/site/festifriends/domain/post/controller/PostApi.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostApi.java
@@ -16,7 +16,6 @@ import site.festifriends.domain.post.dto.PostCreateResponse;
 import site.festifriends.domain.post.dto.PostListCursorResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
 import site.festifriends.domain.post.dto.PostPinRequest;
-import site.festifriends.domain.post.dto.PostPinResponse;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
 import site.festifriends.domain.post.dto.PostUpdateRequest;
 
@@ -138,8 +137,8 @@ public interface PostApi {
             - isPinned: 고정 여부 (true: 고정, false: 해제)
             
             **응답:**
-            - result: 성공 여부
-            - isPinned: 변경된 고정 상태
+            - 고정 시: "게시글이 고정되었습니다."
+            - 해제 시: "게시글 고정이 해제되었습니다."
             
             **참고:**
             - 게시글을 고정(isPinned=true)하면 같은 모임 내 기존 고정글은 자동으로 고정 해제됩니다.
@@ -153,7 +152,7 @@ public interface PostApi {
             @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 고정/해제에 실패했습니다.")
         }
     )
-    ResponseEntity<ResponseWrapper<PostPinResponse>> pinPost(
+    ResponseEntity<ResponseWrapper<Void>> pinPost(
         @AuthenticationPrincipal UserDetailsImpl user,
         @Parameter(description = "모임 ID") @PathVariable Long groupId,
         @Parameter(description = "게시글 ID") @PathVariable Long postId,

--- a/src/main/java/site/festifriends/domain/post/controller/PostApi.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostApi.java
@@ -15,6 +15,8 @@ import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.post.dto.PostCreateRequest;
 import site.festifriends.domain.post.dto.PostCreateResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
+import site.festifriends.domain.post.dto.PostPinRequest;
+import site.festifriends.domain.post.dto.PostPinResponse;
 import site.festifriends.domain.post.dto.PostResponse;
 import site.festifriends.domain.post.dto.PostUpdateRequest;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
@@ -127,4 +129,34 @@ public interface PostApi {
             @AuthenticationPrincipal UserDetailsImpl user,
             @Parameter(description = "모임 ID") @PathVariable Long groupId,
             @Parameter(description = "게시글 ID") @PathVariable Long postId);
+
+    @Operation(
+            summary = "모임 내 게시글 고정/해제",
+            description = """
+                    모임 내 게시글을 고정하거나 고정을 해제합니다. 해당 모임에 속한 회원이면 누구나 고정/해제할 수 있습니다.
+
+                    **요청 본문:**
+                    - isPinned: 고정 여부 (true: 고정, false: 해제)
+
+                    **응답:**
+                    - result: 성공 여부
+                    - isPinned: 변경된 고정 상태
+
+                    **참고:**
+                    - 게시글을 고정(isPinned=true)하면 같은 모임 내 기존 고정글은 자동으로 고정 해제됩니다.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "게시글 고정/해제가 성공적으로 처리되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+                    @ApiResponse(responseCode = "403", description = "해당 모임에 속한 회원만 게시글을 고정/해제할 수 있습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 모임 또는 게시글을 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 고정/해제에 실패했습니다.")
+            }
+    )
+    ResponseEntity<ResponseWrapper<PostPinResponse>> pinPost(
+            @AuthenticationPrincipal UserDetailsImpl user,
+            @Parameter(description = "모임 ID") @PathVariable Long groupId,
+            @Parameter(description = "게시글 ID") @PathVariable Long postId,
+            @Parameter(description = "게시글 고정/해제 정보") @RequestBody PostPinRequest request);
 }

--- a/src/main/java/site/festifriends/domain/post/controller/PostApi.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostApi.java
@@ -9,154 +9,153 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.post.dto.PostCreateRequest;
 import site.festifriends.domain.post.dto.PostCreateResponse;
+import site.festifriends.domain.post.dto.PostListCursorResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
 import site.festifriends.domain.post.dto.PostPinRequest;
 import site.festifriends.domain.post.dto.PostPinResponse;
-import site.festifriends.domain.post.dto.PostResponse;
-import site.festifriends.domain.post.dto.PostUpdateRequest;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
+import site.festifriends.domain.post.dto.PostUpdateRequest;
 
 @Tag(name = "Post", description = "모임 게시글 관련 API")
 public interface PostApi {
 
     @Operation(
-            summary = "모임 내 게시글 목록 조회",
-            description = """
-                    모임 내 게시글 목록을 커서 기반 페이지네이션으로 조회합니다.
-
-                    **요청 파라미터:**
-                    - cursorId: 이전 응답에서 받은 커서값, 없으면 첫 페이지 조회
-                    - size: 한 번에 가져올 게시글 개수, 기본값 20
-
-                    **응답:**
-                    - 게시글 목록은 고정 게시글(isPinned=true)이 먼저 표시되고, 그 다음 최신순으로 정렬됩니다.
-                    - 각 게시글에는 작성자 정보, 내용, 이미지, 댓글 수, 반응 수 등이 포함됩니다.
-                    """,
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
-                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                    @ApiResponse(responseCode = "403", description = "해당 모임에 속한 회원만 조회 가능"),
-                    @ApiResponse(responseCode = "404", description = "모임을 찾을 수 없음"),
-                    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-            }
+        summary = "모임 내 게시글 목록 조회",
+        description = """
+            모임 내 게시글 목록을 커서 기반 페이지네이션으로 조회합니다.
+            
+            **요청 파라미터:**
+            - cursorId: 이전 응답에서 받은 커서값, 없으면 첫 페이지 조회
+            - size: 한 번에 가져올 게시글 개수, 기본값 20
+            
+            **응답:**
+            - 게시글 목록은 고정 게시글(isPinned=true)이 먼저 표시되고, 그 다음 최신순으로 정렬됩니다.
+            - 각 게시글에는 작성자 정보, 내용, 이미지, 댓글 수, 반응 수 등이 포함됩니다.
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "해당 모임에 속한 회원만 조회 가능"),
+            @ApiResponse(responseCode = "404", description = "모임을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
     )
-    ResponseEntity<CursorResponseWrapper<PostResponse>> getPostsByGroupId(
-            @AuthenticationPrincipal UserDetailsImpl user,
-            @Parameter(description = "모임 ID") @PathVariable Long groupId,
-            @Parameter(description = "요청 파라미터 (cursorId, size)") @ModelAttribute PostListRequest request);
+    ResponseEntity<PostListCursorResponse> getPostsByGroupId(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "요청 파라미터 (cursorId, size)") @ModelAttribute PostListRequest request);
 
     @Operation(
-            summary = "모임 내 게시글 등록",
-            description = """
-                    모임 내 게시글을 등록합니다.
-
-                    **요청 본문:**
-                    - content: 게시글 내용 (필수)
-                    - isPinned: 상단 고정 여부 (선택, 기본값 false)
-                    - images: 첨부 이미지 배열 (선택)
-
-                    **응답:**
-                    - 게시글 등록 성공 여부(result)만 반환됩니다.
-                    - isPinned가 true인 경우, 같은 모임 내 기존 고정글은 자동으로 고정 해제(isPinned=false)됩니다.
-                    """,
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "게시글이 성공적으로 등록되었습니다."),
-                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                    @ApiResponse(responseCode = "403", description = "게시글 등록 권한이 없습니다."),
-                    @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없습니다."),
-                    @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 등록에 실패했습니다.")
-            }
+        summary = "모임 내 게시글 등록",
+        description = """
+            모임 내 게시글을 등록합니다.
+            
+            **요청 본문:**
+            - content: 게시글 내용 (필수)
+            - isPinned: 상단 고정 여부 (선택, 기본값 false)
+            - images: 첨부 이미지 배열 (선택)
+            
+            **응답:**
+            - 게시글 등록 성공 여부(result)만 반환됩니다.
+            - isPinned가 true인 경우, 같은 모임 내 기존 고정글은 자동으로 고정 해제(isPinned=false)됩니다.
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글이 성공적으로 등록되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "게시글 등록 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 등록에 실패했습니다.")
+        }
     )
     ResponseEntity<ResponseWrapper<PostCreateResponse>> createPost(
-            @AuthenticationPrincipal UserDetailsImpl user,
-            @Parameter(description = "모임 ID") @PathVariable Long groupId,
-            @Parameter(description = "게시글 등록 정보") @RequestBody PostCreateRequest request);
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 등록 정보") @RequestBody PostCreateRequest request);
 
     @Operation(
-            summary = "모임 내 게시글 수정",
-            description = """
-                    모임 내 게시글을 수정합니다. 게시글 작성자만 수정할 수 있습니다.
-
-                    **요청 본문:**
-                    - content: 게시글 내용 (선택)
-                    - isPinned: 상단 고정 여부 (선택)
-                    - images: 첨부 이미지 배열 (선택)
-
-                    **응답:**
-                    - 게시글 수정 성공 여부(result)만 반환됩니다.
-                    - isPinned가 true인 경우, 같은 모임 내 기존 고정글은 자동으로 고정 해제(isPinned=false)됩니다.
-                    """,
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "게시글이 성공적으로 수정되었습니다."),
-                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                    @ApiResponse(responseCode = "403", description = "게시글 수정 권한이 없습니다."),
-                    @ApiResponse(responseCode = "404", description = "해당 모임 또는 게시글을 찾을 수 없습니다."),
-                    @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 수정에 실패했습니다.")
-            }
+        summary = "모임 내 게시글 수정",
+        description = """
+            모임 내 게시글을 수정합니다. 게시글 작성자만 수정할 수 있습니다.
+            
+            **요청 본문:**
+            - content: 게시글 내용 (선택)
+            - isPinned: 상단 고정 여부 (선택)
+            - images: 첨부 이미지 배열 (선택)
+            
+            **응답:**
+            - 게시글 수정 성공 여부(result)만 반환됩니다.
+            - isPinned가 true인 경우, 같은 모임 내 기존 고정글은 자동으로 고정 해제(isPinned=false)됩니다.
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글이 성공적으로 수정되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "게시글 수정 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "해당 모임 또는 게시글을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 수정에 실패했습니다.")
+        }
     )
     ResponseEntity<ResponseWrapper<PostUpdateDeleteResponse>> updatePost(
-            @AuthenticationPrincipal UserDetailsImpl user,
-            @Parameter(description = "모임 ID") @PathVariable Long groupId,
-            @Parameter(description = "게시글 ID") @PathVariable Long postId,
-            @Parameter(description = "게시글 수정 정보") @RequestBody PostUpdateRequest request);
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 ID") @PathVariable Long postId,
+        @Parameter(description = "게시글 수정 정보") @RequestBody PostUpdateRequest request);
 
     @Operation(
-            summary = "모임 내 게시글 삭제",
-            description = """
-                    모임 내 게시글을 삭제합니다. 게시글 작성자만 삭제할 수 있습니다.
-
-                    **응답:**
-                    - 게시글 삭제 성공 여부(result)만 반환됩니다.
-                    """,
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "게시글이 성공적으로 삭제되었습니다."),
-                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                    @ApiResponse(responseCode = "403", description = "게시글 삭제 권한이 없습니다."),
-                    @ApiResponse(responseCode = "404", description = "해당 모임 또는 게시글을 찾을 수 없습니다."),
-                    @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 삭제에 실패했습니다.")
-            }
+        summary = "모임 내 게시글 삭제",
+        description = """
+            모임 내 게시글을 삭제합니다. 게시글 작성자만 삭제할 수 있습니다.
+            
+            **응답:**
+            - 게시글 삭제 성공 여부(result)만 반환됩니다.
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글이 성공적으로 삭제되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "게시글 삭제 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "해당 모임 또는 게시글을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 삭제에 실패했습니다.")
+        }
     )
     ResponseEntity<ResponseWrapper<PostUpdateDeleteResponse>> deletePost(
-            @AuthenticationPrincipal UserDetailsImpl user,
-            @Parameter(description = "모임 ID") @PathVariable Long groupId,
-            @Parameter(description = "게시글 ID") @PathVariable Long postId);
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 ID") @PathVariable Long postId);
 
     @Operation(
-            summary = "모임 내 게시글 고정/해제",
-            description = """
-                    모임 내 게시글을 고정하거나 고정을 해제합니다. 해당 모임에 속한 회원이면 누구나 고정/해제할 수 있습니다.
-
-                    **요청 본문:**
-                    - isPinned: 고정 여부 (true: 고정, false: 해제)
-
-                    **응답:**
-                    - result: 성공 여부
-                    - isPinned: 변경된 고정 상태
-
-                    **참고:**
-                    - 게시글을 고정(isPinned=true)하면 같은 모임 내 기존 고정글은 자동으로 고정 해제됩니다.
-                    """,
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "게시글 고정/해제가 성공적으로 처리되었습니다."),
-                    @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-                    @ApiResponse(responseCode = "403", description = "해당 모임에 속한 회원만 게시글을 고정/해제할 수 있습니다."),
-                    @ApiResponse(responseCode = "404", description = "해당 모임 또는 게시글을 찾을 수 없습니다."),
-                    @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 고정/해제에 실패했습니다.")
-            }
+        summary = "모임 내 게시글 고정/해제",
+        description = """
+            모임 내 게시글을 고정하거나 고정을 해제합니다. 해당 모임에 속한 회원이면 누구나 고정/해제할 수 있습니다.
+            
+            **요청 본문:**
+            - isPinned: 고정 여부 (true: 고정, false: 해제)
+            
+            **응답:**
+            - result: 성공 여부
+            - isPinned: 변경된 고정 상태
+            
+            **참고:**
+            - 게시글을 고정(isPinned=true)하면 같은 모임 내 기존 고정글은 자동으로 고정 해제됩니다.
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 고정/해제가 성공적으로 처리되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "해당 모임에 속한 회원만 게시글을 고정/해제할 수 있습니다."),
+            @ApiResponse(responseCode = "404", description = "해당 모임 또는 게시글을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 고정/해제에 실패했습니다.")
+        }
     )
     ResponseEntity<ResponseWrapper<PostPinResponse>> pinPost(
-            @AuthenticationPrincipal UserDetailsImpl user,
-            @Parameter(description = "모임 ID") @PathVariable Long groupId,
-            @Parameter(description = "게시글 ID") @PathVariable Long postId,
-            @Parameter(description = "게시글 고정/해제 정보") @RequestBody PostPinRequest request);
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 ID") @PathVariable Long postId,
+        @Parameter(description = "게시글 고정/해제 정보") @RequestBody PostPinRequest request);
 }

--- a/src/main/java/site/festifriends/domain/post/controller/PostController.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostController.java
@@ -18,6 +18,8 @@ import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.post.dto.PostCreateRequest;
 import site.festifriends.domain.post.dto.PostCreateResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
+import site.festifriends.domain.post.dto.PostPinRequest;
+import site.festifriends.domain.post.dto.PostPinResponse;
 import site.festifriends.domain.post.dto.PostResponse;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
 import site.festifriends.domain.post.dto.PostUpdateRequest;
@@ -37,7 +39,8 @@ public class PostController implements PostApi {
         @PathVariable Long groupId,
         PostListRequest request
     ) {
-        CursorResponseWrapper<PostResponse> response = postService.getPostsByGroupId(groupId, user.getMemberId(), request);
+        CursorResponseWrapper<PostResponse> response = postService.getPostsByGroupId(groupId, user.getMemberId(),
+            request);
 
         return ResponseEntity.ok(response);
     }
@@ -77,5 +80,22 @@ public class PostController implements PostApi {
         PostUpdateDeleteResponse response = postService.deletePost(groupId, postId, user.getMemberId());
 
         return ResponseEntity.ok(ResponseWrapper.success("게시글이 성공적으로 삭제되었습니다.", response));
+    }
+
+    @Override
+    @PatchMapping("/{groupId}/posts/{postId}/pinned")
+    public ResponseEntity<ResponseWrapper<PostPinResponse>> pinPost(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long groupId,
+        @PathVariable Long postId,
+        @RequestBody PostPinRequest request
+    ) {
+        PostPinResponse response = postService.pinPost(groupId, postId, user.getMemberId(), request);
+
+        String message = Boolean.TRUE.equals(request.getIsPinned())
+            ? "게시글이 성공적으로 고정되었습니다."
+            : "게시글 고정이 해제되었습니다.";
+
+        return ResponseEntity.ok(ResponseWrapper.success(message, response));
     }
 }

--- a/src/main/java/site/festifriends/domain/post/controller/PostController.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostController.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
+
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/site/festifriends/domain/post/controller/PostController.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostController.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,7 +16,9 @@ import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.post.dto.PostCreateRequest;
 import site.festifriends.domain.post.dto.PostCreateResponse;
+import site.festifriends.domain.post.dto.PostListCursorResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
+import site.festifriends.domain.post.dto.PostListResponse;
 import site.festifriends.domain.post.dto.PostPinRequest;
 import site.festifriends.domain.post.dto.PostPinResponse;
 import site.festifriends.domain.post.dto.PostResponse;
@@ -34,13 +35,22 @@ public class PostController implements PostApi {
 
     @Override
     @GetMapping("/{groupId}/posts")
-    public ResponseEntity<CursorResponseWrapper<PostResponse>> getPostsByGroupId(
+    public ResponseEntity<PostListCursorResponse> getPostsByGroupId(
         @AuthenticationPrincipal UserDetailsImpl user,
         @PathVariable Long groupId,
         PostListRequest request
     ) {
-        CursorResponseWrapper<PostResponse> response = postService.getPostsByGroupId(groupId, user.getMemberId(),
+        CursorResponseWrapper<PostResponse> postResponse = postService.getPostsByGroupId(groupId, user.getMemberId(),
             request);
+
+        PostListResponse data = PostListResponse.of(groupId, postResponse.getData());
+
+        PostListCursorResponse response = PostListCursorResponse.success(
+            "게시글 목록 조회 성공.",
+            data,
+            postResponse.getCursorId(),
+            postResponse.getHasNext()
+        );
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/site/festifriends/domain/post/controller/PostController.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostController.java
@@ -20,7 +20,6 @@ import site.festifriends.domain.post.dto.PostListCursorResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
 import site.festifriends.domain.post.dto.PostListResponse;
 import site.festifriends.domain.post.dto.PostPinRequest;
-import site.festifriends.domain.post.dto.PostPinResponse;
 import site.festifriends.domain.post.dto.PostResponse;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
 import site.festifriends.domain.post.dto.PostUpdateRequest;
@@ -94,18 +93,18 @@ public class PostController implements PostApi {
 
     @Override
     @PatchMapping("/{groupId}/posts/{postId}/pinned")
-    public ResponseEntity<ResponseWrapper<PostPinResponse>> pinPost(
+    public ResponseEntity<ResponseWrapper<Void>> pinPost(
         @AuthenticationPrincipal UserDetailsImpl user,
         @PathVariable Long groupId,
         @PathVariable Long postId,
         @RequestBody PostPinRequest request
     ) {
-        PostPinResponse response = postService.pinPost(groupId, postId, user.getMemberId(), request);
+        postService.pinPost(groupId, postId, user.getMemberId(), request);
 
         String message = Boolean.TRUE.equals(request.getIsPinned())
-            ? "게시글이 성공적으로 고정되었습니다."
+            ? "게시글이 고정되었습니다."
             : "게시글 고정이 해제되었습니다.";
 
-        return ResponseEntity.ok(ResponseWrapper.success(message, response));
+        return ResponseEntity.ok(ResponseWrapper.success(message));
     }
 }

--- a/src/main/java/site/festifriends/domain/post/dto/PostAuthorResponse.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostAuthorResponse.java
@@ -1,0 +1,22 @@
+package site.festifriends.domain.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.entity.Member;
+
+@Getter
+@Builder
+public class PostAuthorResponse {
+
+    private Long id;
+    private String name;
+    private String profileImage;
+
+    public static PostAuthorResponse from(Member member) {
+        return PostAuthorResponse.builder()
+            .id(member.getId())
+            .name(member.getNickname())
+            .profileImage(member.getProfileImageUrl())
+            .build();
+    }
+}

--- a/src/main/java/site/festifriends/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostCreateRequest.java
@@ -16,7 +16,7 @@ public class PostCreateRequest {
     @Getter
     @Setter
     public static class PostImageCreateRequest {
-        private String name;
-        private String url;
+        private String alt;
+        private String src;
     }
 }

--- a/src/main/java/site/festifriends/domain/post/dto/PostListCursorResponse.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostListCursorResponse.java
@@ -1,0 +1,26 @@
+package site.festifriends.domain.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostListCursorResponse {
+
+    private Integer code;
+    private String message;
+    private PostListResponse data;
+    private Long cursorId;
+    private Boolean hasNext;
+
+    public static PostListCursorResponse success(String message, PostListResponse data, Long cursorId,
+        Boolean hasNext) {
+        return PostListCursorResponse.builder()
+            .code(200)
+            .message(message)
+            .data(data)
+            .cursorId(cursorId)
+            .hasNext(hasNext)
+            .build();
+    }
+}

--- a/src/main/java/site/festifriends/domain/post/dto/PostListResponse.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostListResponse.java
@@ -9,29 +9,13 @@ import java.util.List;
 @Builder
 public class PostListResponse {
 
-    private Integer code;
-    private String message;
-    private Long cursorId;
-    private boolean hasNext;
-    private PostListData data;
+    private Long groupId;
+    private List<PostResponse> posts;
 
-    @Getter
-    @Builder
-    public static class PostListData {
-        private Long groupId;
-        private List<PostResponse> posts;
-    }
-
-    public static PostListResponse of(Integer code, String message, Long cursorId, boolean hasNext, Long groupId, List<PostResponse> posts) {
+    public static PostListResponse of(Long groupId, List<PostResponse> posts) {
         return PostListResponse.builder()
-                .code(code)
-                .message(message)
-                .cursorId(cursorId)
-                .hasNext(hasNext)
-                .data(PostListData.builder()
-                        .groupId(groupId)
-                        .posts(posts)
-                        .build())
-                .build();
+            .groupId(groupId)
+            .posts(posts)
+            .build();
     }
 }

--- a/src/main/java/site/festifriends/domain/post/dto/PostPinRequest.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostPinRequest.java
@@ -1,0 +1,17 @@
+package site.festifriends.domain.post.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostPinRequest {
+
+    @JsonProperty("isPinned")
+    private Boolean isPinned;
+
+    public Boolean getIsPinned() {
+        return isPinned;
+    }
+}

--- a/src/main/java/site/festifriends/domain/post/dto/PostPinResponse.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostPinResponse.java
@@ -1,0 +1,28 @@
+package site.festifriends.domain.post.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+public class PostPinResponse extends PostUpdateDeleteResponse {
+
+    @JsonProperty("isPinned")
+    private boolean isPinned;
+
+    public boolean isPinned() {
+        return isPinned;
+    }
+
+    /**
+     * 성공 응답 생성
+     */
+    public static PostPinResponse success(boolean isPinned) {
+        PostPinResponse response = new PostPinResponse();
+        response.setResult(true);
+        response.setPinned(isPinned);
+        return response;
+    }
+}

--- a/src/main/java/site/festifriends/domain/post/dto/PostResponse.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostResponse.java
@@ -28,7 +28,7 @@ public class PostResponse {
 
     private int imageCount;
     private List<PostImageResponse> images;
-    private Long authorId;
+    private PostAuthorResponse author;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private int commentCount;
@@ -42,21 +42,21 @@ public class PostResponse {
         boolean isMine = currentUserId != null && post.isMine(currentUserId);
 
         return PostResponse.builder()
-                .id(post.getId())
-                .groupId(post.getGroup().getId())
-                .content(post.getContent())
-                .isPinned(post.isPinned())
-                .isReported(post.isReported())
-                .isMine(isMine)
-                .imageCount(post.getImageCount())
-                .images(post.getImages().stream()
-                        .map(PostImageResponse::from)
-                        .collect(Collectors.toList()))
-                .authorId(post.getAuthor().getId())
-                .createdAt(post.getCreatedAt())
-                .updatedAt(post.getUpdatedAt())
-                .commentCount(post.getCommentCount())
-                .reactionCount(post.getReactionCount())
-                .build();
+            .id(post.getId())
+            .groupId(post.getGroup().getId())
+            .content(post.getContent())
+            .isPinned(post.isPinned())
+            .isReported(post.isReported())
+            .isMine(isMine)
+            .imageCount(post.getImageCount())
+            .images(post.getImages().stream()
+                .map(PostImageResponse::from)
+                .collect(Collectors.toList()))
+            .author(PostAuthorResponse.from(post.getAuthor()))
+            .createdAt(post.getCreatedAt())
+            .updatedAt(post.getUpdatedAt())
+            .commentCount(post.getCommentCount())
+            .reactionCount(post.getReactionCount())
+            .build();
     }
 }

--- a/src/main/java/site/festifriends/domain/post/dto/PostUpdateRequest.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostUpdateRequest.java
@@ -16,7 +16,7 @@ public class PostUpdateRequest {
     @Getter
     @Setter
     public static class PostImageUpdateRequest {
-        private String name;
-        private String url;
+        private String alt;
+        private String src;
     }
 }

--- a/src/main/java/site/festifriends/domain/post/service/PostService.java
+++ b/src/main/java/site/festifriends/domain/post/service/PostService.java
@@ -115,8 +115,8 @@ public class PostService {
             List<PostImage> images = request.getImages().stream()
                 .map(image -> PostImage.builder()
                     .post(savedPost)
-                    .src(image.getUrl())
-                    .alt(image.getName())
+                    .src(image.getSrc())
+                    .alt(image.getAlt())
                     .build())
                 .collect(Collectors.toList());
 
@@ -163,8 +163,8 @@ public class PostService {
                 List<PostImage> images = request.getImages().stream()
                     .map(image -> PostImage.builder()
                         .post(post)
-                        .src(image.getUrl())
-                        .alt(image.getName())
+                        .src(image.getSrc())
+                        .alt(image.getAlt())
                         .build())
                     .collect(Collectors.toList());
 

--- a/src/main/java/site/festifriends/domain/post/service/PostService.java
+++ b/src/main/java/site/festifriends/domain/post/service/PostService.java
@@ -16,6 +16,8 @@ import site.festifriends.domain.member.repository.MemberRepository;
 import site.festifriends.domain.post.dto.PostCreateRequest;
 import site.festifriends.domain.post.dto.PostCreateResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
+import site.festifriends.domain.post.dto.PostPinRequest;
+import site.festifriends.domain.post.dto.PostPinResponse;
 import site.festifriends.domain.post.dto.PostResponse;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
 import site.festifriends.domain.post.dto.PostUpdateRequest;
@@ -44,7 +46,7 @@ public class PostService {
     public CursorResponseWrapper<PostResponse> getPostsByGroupId(Long groupId, Long memberId, PostListRequest request) {
         // 모임에 속한 회원인지 확인
         boolean isMember = applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.MEMBER) ||
-                applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.HOST);
+            applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.HOST);
 
         if (!isMember) {
             throw new BusinessException(ErrorCode.FORBIDDEN, "해당 모임에 속한 회원만 게시글을 조회할 수 있습니다.");
@@ -58,8 +60,8 @@ public class PostService {
         Slice<Post> postSlice = postRepository.findPostsByGroupIdWithSlice(groupId, cursorId, pageable);
 
         List<PostResponse> postResponses = postSlice.getContent().stream()
-                .map(post -> PostResponse.from(post, memberId))
-                .collect(Collectors.toList());
+            .map(post -> PostResponse.from(post, memberId))
+            .collect(Collectors.toList());
 
         if (postResponses.isEmpty()) {
             return CursorResponseWrapper.empty("게시글 목록이 정상적으로 조회되었습니다.");
@@ -71,10 +73,10 @@ public class PostService {
         }
 
         return CursorResponseWrapper.success(
-                "게시글 목록 조회 성공.",
-                postResponses,
-                nextCursorId,
-                postSlice.hasNext()
+            "게시글 목록 조회 성공.",
+            postResponses,
+            nextCursorId,
+            postSlice.hasNext()
         );
     }
 
@@ -84,23 +86,23 @@ public class PostService {
     @Transactional
     public PostCreateResponse createPost(Long groupId, Long memberId, PostCreateRequest request) {
         Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 회원을 찾을 수 없습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 회원을 찾을 수 없습니다."));
 
         boolean isMember = applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.MEMBER) ||
-                applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.HOST);
+            applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.HOST);
 
         if (!isMember) {
             throw new BusinessException(ErrorCode.FORBIDDEN, "해당 모임에 속한 회원만 게시글을 등록할 수 있습니다.");
         }
 
         Post post = Post.builder()
-                .group(group)
-                .author(member)
-                .content(request.getContent())
-                .build();
+            .group(group)
+            .author(member)
+            .content(request.getContent())
+            .build();
 
         if (Boolean.TRUE.equals(request.getIsPinned())) {
             postRepository.unpinAllPostsInGroup(groupId);
@@ -111,12 +113,12 @@ public class PostService {
 
         if (request.getImages() != null && !request.getImages().isEmpty()) {
             List<PostImage> images = request.getImages().stream()
-                    .map(image -> PostImage.builder()
-                            .post(savedPost)
-                            .src(image.getUrl())
-                            .alt(image.getName())
-                            .build())
-                    .collect(Collectors.toList());
+                .map(image -> PostImage.builder()
+                    .post(savedPost)
+                    .src(image.getUrl())
+                    .alt(image.getName())
+                    .build())
+                .collect(Collectors.toList());
 
             postImageRepository.saveAll(images);
         }
@@ -130,10 +132,10 @@ public class PostService {
     @Transactional
     public PostUpdateDeleteResponse updatePost(Long groupId, Long postId, Long memberId, PostUpdateRequest request) {
         Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
 
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."));
 
         if (!post.getGroup().getId().equals(groupId)) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "해당 모임에 속한 게시글이 아닙니다.");
@@ -159,12 +161,12 @@ public class PostService {
 
             if (!request.getImages().isEmpty()) {
                 List<PostImage> images = request.getImages().stream()
-                        .map(image -> PostImage.builder()
-                                .post(post)
-                                .src(image.getUrl())
-                                .alt(image.getName())
-                                .build())
-                        .collect(Collectors.toList());
+                    .map(image -> PostImage.builder()
+                        .post(post)
+                        .src(image.getUrl())
+                        .alt(image.getName())
+                        .build())
+                    .collect(Collectors.toList());
 
                 postImageRepository.saveAll(images);
             }
@@ -179,10 +181,10 @@ public class PostService {
     @Transactional
     public PostUpdateDeleteResponse deletePost(Long groupId, Long postId, Long memberId) {
         Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
 
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."));
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."));
 
         if (!post.getGroup().getId().equals(groupId)) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "해당 모임에 속한 게시글이 아닙니다.");
@@ -196,5 +198,37 @@ public class PostService {
         post.delete();
 
         return PostUpdateDeleteResponse.success();
+    }
+
+    /**
+     * 모임 내 게시글 고정/해제
+     */
+    @Transactional
+    public PostPinResponse pinPost(Long groupId, Long postId, Long memberId, PostPinRequest request) {
+        Group group = groupRepository.findById(groupId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
+
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."));
+
+        if (!post.getGroup().getId().equals(groupId)) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "해당 모임에 속한 게시글이 아닙니다.");
+        }
+
+        boolean isMember = applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.MEMBER) ||
+            applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.HOST);
+
+        if (!isMember) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "해당 모임에 속한 회원만 게시글을 고정/해제할 수 있습니다.");
+        }
+
+        boolean isPinned = Boolean.TRUE.equals(request.getIsPinned());
+
+        if (isPinned) {
+            postRepository.unpinAllPostsInGroup(groupId);
+        }
+        post.setPinned(isPinned);
+
+        return PostPinResponse.success(isPinned);
     }
 }

--- a/src/main/java/site/festifriends/domain/post/service/PostService.java
+++ b/src/main/java/site/festifriends/domain/post/service/PostService.java
@@ -17,7 +17,6 @@ import site.festifriends.domain.post.dto.PostCreateRequest;
 import site.festifriends.domain.post.dto.PostCreateResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
 import site.festifriends.domain.post.dto.PostPinRequest;
-import site.festifriends.domain.post.dto.PostPinResponse;
 import site.festifriends.domain.post.dto.PostResponse;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
 import site.festifriends.domain.post.dto.PostUpdateRequest;
@@ -204,7 +203,7 @@ public class PostService {
      * 모임 내 게시글 고정/해제
      */
     @Transactional
-    public PostPinResponse pinPost(Long groupId, Long postId, Long memberId, PostPinRequest request) {
+    public void pinPost(Long groupId, Long postId, Long memberId, PostPinRequest request) {
         Group group = groupRepository.findById(groupId)
             .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
 
@@ -228,7 +227,5 @@ public class PostService {
             postRepository.unpinAllPostsInGroup(groupId);
         }
         post.setPinned(isPinned);
-
-        return PostPinResponse.success(isPinned);
     }
 }

--- a/src/main/java/site/festifriends/entity/Performance.java
+++ b/src/main/java/site/festifriends/entity/Performance.java
@@ -118,7 +118,7 @@ public class Performance extends SoftDeleteEntity {
     @CollectionTable(name = "performance_time", joinColumns = @JoinColumn(name = "performance_id"))
     @Column(name = "time")
     @Comment("공연 시간")
-    private List<LocalDateTime> time = new ArrayList<>();
+    private List<String> time = new ArrayList<>();
 
     @OneToMany(mappedBy = "performance", cascade = CascadeType.ALL, orphanRemoval = true)
     @Comment("소개 이미지 목록")
@@ -129,7 +129,7 @@ public class Performance extends SoftDeleteEntity {
         List<String> cast, List<String> crew, String runtime, String age,
         List<String> productionCompany, List<String> agency, List<String> host,
         List<String> organizer, List<String> price, String poster,
-        PerformanceState state, String visit, List<LocalDateTime> time) {
+        PerformanceState state, String visit, List<String> time) {
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/site/festifriends/entity/Post.java
+++ b/src/main/java/site/festifriends/entity/Post.java
@@ -6,11 +6,11 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -23,7 +23,9 @@ import site.festifriends.common.model.SoftDeleteEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "post")
+@Table(name = "post",
+    indexes = @Index(name = "idx_post_pinned",
+        columnList = "is_pinned"))
 public class Post extends SoftDeleteEntity {
 
     @Id
@@ -73,6 +75,7 @@ public class Post extends SoftDeleteEntity {
 
     /**
      * 첨부 이미지 수 계산
+     *
      * @return 이미지 수
      */
     public int getImageCount() {

--- a/src/test/java/site/festifriends/domain/application/service/ApplicationServiceTest.java
+++ b/src/test/java/site/festifriends/domain/application/service/ApplicationServiceTest.java
@@ -18,8 +18,8 @@ import site.festifriends.common.exception.BusinessException;
 import site.festifriends.common.exception.ErrorCode;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.application.dto.ApplicationStatusRequest;
-import site.festifriends.domain.application.dto.ApplicationStatusResponse;
 import site.festifriends.domain.application.repository.ApplicationRepository;
+import site.festifriends.domain.review.repository.ReviewRepository;
 import site.festifriends.entity.Group;
 import site.festifriends.entity.Member;
 import site.festifriends.entity.MemberGroup;
@@ -33,6 +33,9 @@ class ApplicationServiceTest {
 
     @Mock
     private ApplicationRepository applicationRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @InjectMocks
     private ApplicationService applicationService;
@@ -81,19 +84,19 @@ class ApplicationServiceTest {
     void updateApplicationStatus_Accept_Success() {
         // given
         ApplicationStatusRequest request = new ApplicationStatusRequest();
-        request.setStatus("accept");
+        request.setStatus(ApplicationStatus.ACCEPTED);
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 1L, Role.HOST))
                 .willReturn(true);
 
         // when
-        ResponseWrapper<ApplicationStatusResponse> response = 
+        ResponseWrapper<Void> response = 
                 applicationService.updateApplicationStatus(1L, 1L, request);
 
         // then
         assertThat(response.getMessage()).isEqualTo("모임 가입 신청을 수락하였습니다");
-        assertThat(response.getData().getResult()).isTrue();
+        assertThat(response.getData()).isNull();
         assertThat(application.getStatus()).isEqualTo(ApplicationStatus.ACCEPTED);
     }
 
@@ -102,19 +105,19 @@ class ApplicationServiceTest {
     void updateApplicationStatus_Reject_Success() {
         // given
         ApplicationStatusRequest request = new ApplicationStatusRequest();
-        request.setStatus("reject");
+        request.setStatus(ApplicationStatus.REJECTED);
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 1L, Role.HOST))
                 .willReturn(true);
 
         // when
-        ResponseWrapper<ApplicationStatusResponse> response = 
+        ResponseWrapper<Void> response = 
                 applicationService.updateApplicationStatus(1L, 1L, request);
 
         // then
         assertThat(response.getMessage()).isEqualTo("모임 가입 신청을 거절하였습니다");
-        assertThat(response.getData().getResult()).isTrue();
+        assertThat(response.getData()).isNull();
         assertThat(application.getStatus()).isEqualTo(ApplicationStatus.REJECTED);
     }
 
@@ -123,7 +126,7 @@ class ApplicationServiceTest {
     void updateApplicationStatus_ApplicationNotFound() {
         // given
         ApplicationStatusRequest request = new ApplicationStatusRequest();
-        request.setStatus("accept");
+        request.setStatus(ApplicationStatus.ACCEPTED);
 
         given(applicationRepository.findById(999L)).willReturn(Optional.empty());
 
@@ -139,7 +142,7 @@ class ApplicationServiceTest {
     void updateApplicationStatus_NotHost() {
         // given
         ApplicationStatusRequest request = new ApplicationStatusRequest();
-        request.setStatus("accept");
+        request.setStatus(ApplicationStatus.ACCEPTED);
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 2L, Role.HOST))
@@ -165,7 +168,7 @@ class ApplicationServiceTest {
                 .build();
 
         ApplicationStatusRequest request = new ApplicationStatusRequest();
-        request.setStatus("accept");
+        request.setStatus(ApplicationStatus.ACCEPTED);
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 1L, Role.HOST))
@@ -179,11 +182,11 @@ class ApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("잘못된 상태 값으로 요청하면 예외가 발생한다")
+    @DisplayName("PENDING 상태가 아닌 값으로 요청하면 예외가 발생한다")
     void updateApplicationStatus_InvalidStatus() {
         // given
         ApplicationStatusRequest request = new ApplicationStatusRequest();
-        request.setStatus("invalid");
+        request.setStatus(ApplicationStatus.PENDING); // ACCEPTED나 REJECTED가 아닌 값
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 1L, Role.HOST))
@@ -195,4 +198,4 @@ class ApplicationServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.BAD_REQUEST);
     }
-} 
+}

--- a/src/test/java/site/festifriends/domain/performance/repository/PerformanceRepositoryTest.java
+++ b/src/test/java/site/festifriends/domain/performance/repository/PerformanceRepositoryTest.java
@@ -298,7 +298,7 @@ class PerformanceRepositoryTest {
                 .poster("https://example.com/poster.jpg")
                 .state(PerformanceState.UPCOMING)
                 .visit(visit)
-                .time(new ArrayList<>(List.of(startDate, endDate)))
+                .time(new ArrayList<>(List.of(startDate.toString(), endDate.toString())))
                 .build();
         return entityManager.persistAndFlush(performance);
     }


### PR DESCRIPTION
## 📋 Summary
게시글 고정 기능을 추가했습니다. 사용자가 모임 내에서 중요한 게시글을 상단에 고정할 수 있으며, 기존 고정글은 자동으로 해제됩니다.

## 🔧 Changes Made

### 🆕 New Features
- **게시글 고정/해제 API 추가** (`PATCH /api/v1/groups/{groupId}/posts/{postId}/pinned`)
  - 게시글을 상단에 고정하거나 고정을 해제할 수 있습니다
  - 새로운 게시글을 고정하면 기존 고정글은 자동으로 해제됩니다
  - 모임에 속한 모든 회원이 고정/해제 가능합니다

### 🗃️ Database Changes
- **Post 엔티티**: `is_pinned` 컬럼에 인덱스 추가
  ```sql
  CREATE INDEX idx_post_pinned ON post(is_pinned);
  ```

## ✅ Business Logic
1. **고정 요청 시** (`isPinned: true`):
   - 같은 모임 내 기존 고정글들의 고정 상태를 모두 해제
   - 요청한 게시글을 고정 상태로 변경
   
2. **고정 해제 시** (`isPinned: false`):
   - 해당 게시글의 고정 상태만 해제

3. **권한 검증**:
   - 해당 모임에 속한 회원(MEMBER 또는 HOST)만 고정/해제 가능
   - 게시글이 해당 모임에 속해있는지 검증