### PR TITLE
🐛fix: 테이블 변경 및 공연 시간 타입 변경으로 인한 오류 해결

### DIFF
--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceDto.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceDto.java
@@ -27,6 +27,6 @@ public class LikedPerformanceDto {
     private String state;
     private String visit;
     private List<LikedPerformanceImageDto> images;
-    private List<LocalDateTime> time;
+    private List<String> time;
     private Long bookmarkId;
 }

--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
@@ -27,6 +27,6 @@ public class LikedPerformanceResponse {
     private String state;
     private String visit;
     private List<LikedPerformanceImageDto> images;
-    private List<LocalDateTime> time;
+    private List<String> time;
     private Integer groupCount;
 }

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
@@ -1,18 +1,19 @@
 package site.festifriends.domain.performance.repository;
 
+import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.entity.Performance;
 
-import java.util.List;
-import java.util.Map;
-
 public interface PerformanceRepositoryCustom {
-    
+
     Page<Performance> searchPerformancesWithPaging(PerformanceSearchRequest request, Pageable pageable);
-    
+
     Map<Long, Long> findGroupCountsByPerformanceIds(List<Long> performanceIds);
-    
+
     Map<Long, Long> findFavoriteCountsByPerformanceIds(List<Long> performanceIds);
+
+    Map<Long, Integer> getGroupCountsByPerformanceIds(List<Long> performanceIds);
 } 

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryImpl.java
@@ -15,10 +15,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.entity.Performance;
+import site.festifriends.entity.QBookmark;
 import site.festifriends.entity.QGroup;
 import site.festifriends.entity.QPerformance;
-import site.festifriends.entity.QPerformanceBookmark;
 import site.festifriends.entity.QPerformanceImage;
+import site.festifriends.entity.enums.BookmarkType;
 
 @Repository
 @RequiredArgsConstructor
@@ -107,23 +108,26 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 
     @Override
     public Map<Long, Long> findFavoriteCountsByPerformanceIds(List<Long> performanceIds) {
-        QPerformanceBookmark pb = QPerformanceBookmark.performanceBookmark;
+        QBookmark b = QBookmark.bookmark;
 
         List<Object[]> results = queryFactory
-                .select(pb.performance.id, pb.count())
-                .from(pb)
-                .where(pb.performance.id.in(performanceIds))
-                .groupBy(pb.performance.id)
-                .fetch()
-                .stream()
-                .map(tuple -> new Object[]{tuple.get(pb.performance.id), tuple.get(pb.count())})
-                .collect(Collectors.toList());
+            .select(b.targetId, b.count())
+            .from(b)
+            .where(
+                b.type.eq(BookmarkType.PERFORMANCE),
+                b.targetId.in(performanceIds)
+            )
+            .groupBy(b.targetId)
+            .fetch()
+            .stream()
+            .map(tuple -> new Object[]{tuple.get(b.targetId), tuple.get(b.count())})
+            .collect(Collectors.toList());
 
         return results.stream()
-                .collect(Collectors.toMap(
-                        result -> (Long) result[0],
-                        result -> (Long) result[1]
-                ));
+            .collect(Collectors.toMap(
+                result -> (Long) result[0],
+                result -> (Long) result[1]
+            ));
     }
 
     private BooleanExpression titleContains(String title) {

--- a/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
@@ -216,9 +216,9 @@ public class MemberRepositoryTest {
             .state(PerformanceState.UPCOMING)
             .visit("국내")
             .time(List.of(
-                LocalDateTime.of(2025, 5, 30, 18, 0),
-                LocalDateTime.of(2025, 5, 31, 19, 0),
-                LocalDateTime.of(2025, 6, 1, 20, 0)
+                "화요일 ~ 금요일(20:00)",
+                "토요일(16:00,19:00)",
+                "일요일(15:00,18:00)"
             ))
             .build());
 
@@ -267,9 +267,9 @@ public class MemberRepositoryTest {
         assertThat(dto.getImages().get(0).getSrc()).isEqualTo("https://example.com/img1.jpg");
         assertThat(dto.getImages().get(1).getSrc()).isEqualTo("https://example.com/img2.jpg");
         assertThat(dto.getTime()).containsExactly(
-            LocalDateTime.of(2025, 5, 30, 18, 0),
-            LocalDateTime.of(2025, 5, 31, 19, 0),
-            LocalDateTime.of(2025, 6, 1, 20, 0)
+            "화요일 ~ 금요일(20:00)",
+            "토요일(16:00,19:00)",
+            "일요일(15:00,18:00)"
         );
         assertThat(dto.getBookmarkId()).isNotNull();
 

--- a/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
@@ -124,7 +124,7 @@ class MemberServiceTest {
             "UPCOMING",
             "국내",
             List.of(new LikedPerformanceImageDto("1", "https://example.com/img1.jpg", "이미지1")),
-            List.of(LocalDateTime.of(2023, 10, 1, 18, 0)),
+            List.of("화요일 ~ 금요일(20:00)"),
             100L // bookmarkId
         );
 
@@ -147,7 +147,7 @@ class MemberServiceTest {
             "UPCOMING",
             "국내",
             List.of(new LikedPerformanceImageDto("2", "https://example.com/img2.jpg", "이미지2")),
-            List.of(LocalDateTime.of(2023, 11, 1, 18, 0)),
+            List.of("토요일(16:00,19:00)"),
             101L // bookmarkId
         );
 


### PR DESCRIPTION
## 작업 내용
- [🐛fix: PerformanceBookmark -> Bookmark 사용으로 쿼리 변경](https://github.com/FestiFriends/ff_backend/commit/a9bed914b68bb4b507a1fe2dc6656b17097dfe48)
  - 기존 PerformanceBookmark 을 이용한 쿼리에서 Bookmark를 이용한 쿼리로 변경했습니다.
  - Bookmark의 targetId, type을 사용해 기존과 동일한 결과값을 반환하도록 하였습니다.

- [🐛fix: 공연 시간 String 변경으로 인한 코드 변경](https://github.com/FestiFriends/ff_backend/commit/c740b942ceec404c3a5295974792dcade5cf307c)
  - 공연 시간을 LocalDateTime에서 String 형태 변경으로 인해 쿼리를 변경했습니다.
  - 가져온 데이터를 split 하여 List형태로 반환하는 `splitToList` 메소드에 구분자 파라미터를 받도록 변경했습니다.
  - 공연 시간의 경우 `,(쉼표)`가 섞여 있어, 구분자로 '\\|' 을 사용하는 방식으로 변경하였습니다.