### PR TITLE
✨feat: AWS S3 presigned url 발급 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,13 +50,17 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // aws s3
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0")
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-s3")
 }
 
 // QueryDSL Q클래스 생성 설정
 def querydslDir = "$buildDir/generated/querydsl"
 
 sourceSets {
-    main.java.srcDirs += [ querydslDir ]
+    main.java.srcDirs += [querydslDir]
 }
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/site/festifriends/common/config/S3Config.java
+++ b/src/main/java/site/festifriends/common/config/S3Config.java
@@ -1,0 +1,34 @@
+package site.festifriends.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(accessKey, secretKey)
+        );
+
+        return S3Presigner.builder()
+            .credentialsProvider(credentialsProvider)
+            .region(Region.of(region))
+            .build();
+    }
+
+}

--- a/src/main/java/site/festifriends/common/exception/ErrorCode.java
+++ b/src/main/java/site/festifriends/common/exception/ErrorCode.java
@@ -13,14 +13,18 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
-    
+
     // Review 관련 에러
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "모임을 찾을 수 없습니다."),
     TARGET_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰 대상 사용자를 찾을 수 없습니다."),
     NOT_GROUP_PARTICIPANT(HttpStatus.FORBIDDEN, "해당 모임에 참여하지 않은 사용자입니다."),
     GROUP_NOT_ENDED(HttpStatus.BAD_REQUEST, "아직 종료되지 않은 모임입니다."),
     REVIEW_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 사용자에게 리뷰를 작성했습니다."),
-    CANNOT_REVIEW_SELF(HttpStatus.BAD_REQUEST, "자신에게는 리뷰를 작성할 수 없습니다.");
+    CANNOT_REVIEW_SELF(HttpStatus.BAD_REQUEST, "자신에게는 리뷰를 작성할 수 없습니다."),
+
+    // 파일 업로드 관련 에러
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 확장자입니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/site/festifriends/common/s3/S3Uploader.java
+++ b/src/main/java/site/festifriends/common/s3/S3Uploader.java
@@ -1,6 +1,7 @@
 package site.festifriends.common.s3;
 
 import java.time.Duration;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -18,9 +19,15 @@ public class S3Uploader {
     private final S3Presigner s3Presigner;
 
     public String getPreSignedUrl(String fileName) {
+        String extension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+
+        String uuid = UUID.randomUUID().toString();
+
+        String key = uuid + extension;
+
         PutObjectRequest objectRequest = PutObjectRequest.builder()
             .bucket(bucket)
-            .key(fileName)
+            .key(key)
             .build();
 
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()

--- a/src/main/java/site/festifriends/common/s3/S3Uploader.java
+++ b/src/main/java/site/festifriends/common/s3/S3Uploader.java
@@ -1,0 +1,33 @@
+package site.festifriends.common.s3;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final S3Presigner s3Presigner;
+
+    public String getPreSignedUrl(String fileName) {
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+            .bucket(bucket)
+            .key(fileName)
+            .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+            .signatureDuration(Duration.ofMinutes(15))
+            .putObjectRequest(objectRequest)
+            .build();
+
+        return s3Presigner.presignPutObject(presignRequest).url().toString();
+    }
+}

--- a/src/main/java/site/festifriends/domain/image/controller/ImageController.java
+++ b/src/main/java/site/festifriends/domain/image/controller/ImageController.java
@@ -1,0 +1,28 @@
+package site.festifriends.domain.image.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.ResponseWrapper;
+import site.festifriends.domain.image.dto.UploadImageRequest;
+import site.festifriends.domain.image.dto.UploadImageResponse;
+import site.festifriends.domain.image.service.ImageService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping("/presigned")
+    public ResponseEntity<?> getPreSignedUrl(@RequestBody UploadImageRequest request) {
+        return ResponseEntity.ok().body(ResponseWrapper.success(
+            "url이 성공적으로 생성되었습니다.",
+            new UploadImageResponse(imageService.getPreSignedUrl(request.getFileName())))
+        );
+    }
+}

--- a/src/main/java/site/festifriends/domain/image/dto/UploadImageRequest.java
+++ b/src/main/java/site/festifriends/domain/image/dto/UploadImageRequest.java
@@ -1,0 +1,10 @@
+package site.festifriends.domain.image.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UploadImageRequest {
+
+    private String fileName;
+
+}

--- a/src/main/java/site/festifriends/domain/image/dto/UploadImageResponse.java
+++ b/src/main/java/site/festifriends/domain/image/dto/UploadImageResponse.java
@@ -1,0 +1,13 @@
+package site.festifriends.domain.image.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UploadImageResponse {
+
+    private String presignedUrl;
+
+    public UploadImageResponse(String presignedUrl) {
+        this.presignedUrl = presignedUrl;
+    }
+}

--- a/src/main/java/site/festifriends/domain/image/service/ImageService.java
+++ b/src/main/java/site/festifriends/domain/image/service/ImageService.java
@@ -1,0 +1,16 @@
+package site.festifriends.domain.image.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.festifriends.common.s3.S3Uploader;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Uploader s3Uploader;
+
+    public String getPreSignedUrl(String fileName) {
+        return s3Uploader.getPreSignedUrl(fileName);
+    }
+}

--- a/src/main/java/site/festifriends/domain/image/service/ImageService.java
+++ b/src/main/java/site/festifriends/domain/image/service/ImageService.java
@@ -2,6 +2,8 @@ package site.festifriends.domain.image.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import site.festifriends.common.exception.BusinessException;
+import site.festifriends.common.exception.ErrorCode;
 import site.festifriends.common.s3.S3Uploader;
 
 @Service
@@ -11,6 +13,30 @@ public class ImageService {
     private final S3Uploader s3Uploader;
 
     public String getPreSignedUrl(String fileName) {
+        if (!validateExtension(fileName)) {
+            throw new BusinessException(ErrorCode.INVALID_FILE_EXTENSION, "지원하지 않는 파일 확장자입니다.");
+        }
         return s3Uploader.getPreSignedUrl(fileName);
+    }
+
+    private boolean validateExtension(String fileName) {
+        String[] validExtensions = {".jpg", ".png", ".gif", ".webp"};
+
+        if (fileName == null || !fileName.contains(".")) {
+            return false;
+        }
+
+        String extension = fileName.substring(fileName.lastIndexOf(".")).toLowerCase();
+
+        if (extension.isEmpty()) {
+            return false;
+        }
+
+        for (String validExtension : validExtensions) {
+            if (validExtension.equals(extension)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,16 @@ spring:
         default_batch_fetch_size: 100
         format_sql: true
     open-in-view: false
+  cloud:
+    aws:
+      s3:
+        bucket: ${AWS_S3_BUCKET}
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+
 
 logging:
   level:


### PR DESCRIPTION
## 작업 내용
- [🔧feat: aws s3 관련 설정 등록](https://github.com/FestiFriends/ff_backend/commit/90d29702d5fb026d34598e6fae6387d1c5900fd2)
  - aws s3을 이용하기 위해 관련 의존성 및 설정값들을 추가하였습니다.
  - AWS키를 이용해 인증 객체를 설정하는 S3Config 파일을 추가했습니다.

- [✨feat: aws s3을 이용해 presigned url 발급 로직 생성](https://github.com/FestiFriends/ff_backend/commit/dfd82d387e8c968d8c3ef8d40fd9625c9749ff5b)
  - 파일 이름을 바탕으로 presigned url을 생성하는 로직을 작성하였습니다.

- [✨feat: 파일 확장자에 대한 검증 부분 추가](https://github.com/FestiFriends/ff_backend/pull/20/commits/cd511adace14b1a8caf97efffa68de4cafc974ff)
  - 파일 확장자에 대한 검증 부분을 추가했습니다.(확장자 존재 여부 및 지원하는 확장자만 통과하도록 변경)

- [✨feat: 파일 key값을 UUID를 이용하도록 변경](https://github.com/FestiFriends/ff_backend/pull/20/commits/fb3ebf5344d6f462dab1b148594680bc23dce544)
  - 별도의 디렉토리 형식으로 관리하지 않고 이미지를 uuid를 이용해 중복되지 않도록만 처리했습니다.
