### PR TITLE
게시글 반응 및 상세조회 기능 추가

### DIFF
--- a/src/main/java/site/festifriends/common/config/SecurityConfig.java
+++ b/src/main/java/site/festifriends/common/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
         "/swagger-ui/**", "/swagger",
         "/api/v1/auth/**",
         "/api/v1/performances",
-        "/api/v1/performances/**"
+        "/api/v1/performances/**",
+        "/api/v1/performances/top-favorites"
     };
 
     @Bean

--- a/src/main/java/site/festifriends/common/config/SecurityConfig.java
+++ b/src/main/java/site/festifriends/common/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
         "/api/v1/auth/**",
         "/api/v1/performances",
         "/api/v1/performances/**",
-        "/api/v1/performances/top-favorites"
+        "/api/v1/performances/top-favorites",
+        "/api/v1/performances/top-groups"
     };
 
     @Bean

--- a/src/main/java/site/festifriends/domain/application/dto/ApplicationListResponse.java
+++ b/src/main/java/site/festifriends/domain/application/dto/ApplicationListResponse.java
@@ -1,24 +1,27 @@
 package site.festifriends.domain.application.dto;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import site.festifriends.entity.enums.ApplicationStatus;
 import site.festifriends.entity.enums.Gender;
-
-import java.time.LocalDateTime;
-import java.util.List;
+import site.festifriends.entity.enums.GroupCategory;
 
 @Getter
 @Builder
 public class ApplicationListResponse {
+
     private String groupId;
     private String groupName;
     private String poster;
+    private GroupCategory category;
     private List<ApplicationInfo> applications;
 
     @Getter
     @Builder
     public static class ApplicationInfo {
+
         private String applicationId;
         private String userId;
         private String nickname;

--- a/src/main/java/site/festifriends/domain/application/dto/AppliedListResponse.java
+++ b/src/main/java/site/festifriends/domain/application/dto/AppliedListResponse.java
@@ -1,22 +1,25 @@
 package site.festifriends.domain.application.dto;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import site.festifriends.entity.enums.ApplicationStatus;
 import site.festifriends.entity.enums.Gender;
-
-import java.time.LocalDateTime;
+import site.festifriends.entity.enums.GroupCategory;
 
 @Getter
 @Builder
 public class AppliedListResponse {
+
     private String applicationId;
     private String performanceId;
     private String poster;
     private String groupId;
     private String groupName;
+    private GroupCategory category;
     private String hostName;
     private Double hostRating;
+    private String hostProfileImage;
     private Gender gender;
     private String applicationText;
     private LocalDateTime createdAt;

--- a/src/main/java/site/festifriends/domain/application/dto/JoinedGroupResponse.java
+++ b/src/main/java/site/festifriends/domain/application/dto/JoinedGroupResponse.java
@@ -46,5 +46,6 @@ public class JoinedGroupResponse {
         private String id;
         private String name;
         private Double rating;
+        private String profileImage;
     }
 } 

--- a/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
+++ b/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
@@ -16,17 +16,17 @@ import site.festifriends.common.exception.ErrorCode;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.application.dto.ApplicationListResponse;
+import site.festifriends.domain.application.dto.ApplicationRequest;
 import site.festifriends.domain.application.dto.ApplicationStatusRequest;
 import site.festifriends.domain.application.dto.ApplicationStatusResponse;
 import site.festifriends.domain.application.dto.AppliedListResponse;
 import site.festifriends.domain.application.dto.JoinedGroupResponse;
-import site.festifriends.domain.application.dto.ApplicationRequest;
 import site.festifriends.domain.application.repository.ApplicationRepository;
 import site.festifriends.domain.group.repository.GroupRepository;
 import site.festifriends.domain.member.repository.MemberRepository;
 import site.festifriends.domain.review.repository.ReviewRepository;
-import site.festifriends.entity.Member;
 import site.festifriends.entity.Group;
+import site.festifriends.entity.Member;
 import site.festifriends.entity.MemberGroup;
 import site.festifriends.entity.enums.AgeRange;
 import site.festifriends.entity.enums.ApplicationStatus;
@@ -97,6 +97,7 @@ public class ApplicationService {
                     .groupId(firstApp.getGroup().getId().toString())
                     .groupName(firstApp.getGroup().getTitle())
                     .poster(firstApp.getGroup().getPerformance().getPoster())
+                    .category(firstApp.getGroup().getGatherType())
                     .applications(applicationInfos)
                     .build();
             })

--- a/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
+++ b/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
@@ -158,6 +158,7 @@ public class ApplicationService {
                 MemberGroup hostInfo = hostInfoMap.get(app.getGroup().getId());
                 String hostNickname = hostInfo != null ? hostInfo.getMember().getNickname() : "알 수 없음";
                 Long hostId = hostInfo != null ? hostInfo.getMember().getId() : null;
+                String hostProfileImage = hostInfo != null ? hostInfo.getMember().getProfileImageUrl() : null;
 
                 return AppliedListResponse.builder()
                     .applicationId(app.getId().toString())
@@ -165,8 +166,10 @@ public class ApplicationService {
                     .poster(app.getGroup().getPerformance().getPoster())
                     .groupId(app.getGroup().getId().toString())
                     .groupName(app.getGroup().getTitle())
+                    .category(app.getGroup().getGatherType())
                     .hostName(hostNickname)
                     .hostRating(hostRatingMap.getOrDefault(hostId, 0.0))
+                    .hostProfileImage(hostProfileImage)
                     .gender(app.getGroup().getGenderType())
                     .applicationText(app.getApplicationText())
                     .createdAt(app.getCreatedAt())

--- a/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
+++ b/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
@@ -267,6 +267,7 @@ public class ApplicationService {
                         .name(hostInfo != null ? hostInfo.getMember().getNickname() : "알 수 없음")
                         .rating(hostRatingMap.getOrDefault(
                             hostInfo != null ? hostInfo.getMember().getId() : null, 0.0))
+                        .profileImage(hostInfo != null ? hostInfo.getMember().getProfileImageUrl() : null)
                         .build())
                     .isHost(isHost)
                     .build();

--- a/src/main/java/site/festifriends/domain/comment/controller/CommentApi.java
+++ b/src/main/java/site/festifriends/domain/comment/controller/CommentApi.java
@@ -7,7 +7,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.comment.dto.CommentCreateRequest;
 import site.festifriends.domain.comment.dto.CommentListCursorResponse;
 import site.festifriends.domain.comment.dto.CommentListRequest;
 
@@ -42,4 +45,30 @@ public interface CommentApi {
         @Parameter(description = "모임 ID") @PathVariable Long groupId,
         @Parameter(description = "게시글 ID") @PathVariable Long postId,
         @Parameter(description = "요청 파라미터 (cursor, size)") CommentListRequest request);
+
+    @Operation(
+        summary = "게시글 댓글 작성",
+        description = """
+            모임에 참가한 사용자가 특정 게시글에 댓글을 작성합니다.
+            
+            **요청:**
+            - content: 댓글 내용 (필수, 최대 500자)
+            
+            **응답:**
+            - 작성된 댓글의 정보가 반환됩니다.
+            - 댓글 ID, 작성자 정보, 내용, 작성 시간이 포함됩니다.
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "댓글이 성공적으로 등록되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "403", description = "댓글 등록 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 댓글 등록에 실패했습니다.")
+        }
+    )
+    ResponseEntity<ResponseWrapper<Void>> createComment(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 ID") @PathVariable Long postId,
+        @Parameter(description = "댓글 작성 요청") @RequestBody CommentCreateRequest request);
 }

--- a/src/main/java/site/festifriends/domain/comment/controller/CommentApi.java
+++ b/src/main/java/site/festifriends/domain/comment/controller/CommentApi.java
@@ -13,6 +13,7 @@ import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.comment.dto.CommentCreateRequest;
 import site.festifriends.domain.comment.dto.CommentListCursorResponse;
 import site.festifriends.domain.comment.dto.CommentListRequest;
+import site.festifriends.domain.comment.dto.CommentUpdateRequest;
 
 @Tag(name = "Comment", description = "게시글 댓글 관련 API")
 public interface CommentApi {
@@ -71,4 +72,52 @@ public interface CommentApi {
         @Parameter(description = "모임 ID") @PathVariable Long groupId,
         @Parameter(description = "게시글 ID") @PathVariable Long postId,
         @Parameter(description = "댓글 작성 요청") @RequestBody CommentCreateRequest request);
+
+    @Operation(
+        summary = "게시글 댓글 수정",
+        description = """
+            댓글 작성자가 자신의 댓글 내용을 수정합니다.
+            
+            **요청:**
+            - content: 수정된 댓글 내용 (필수, 최대 500자)
+            
+            **권한:**
+            - 댓글 작성자만 수정 가능
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "댓글이 성공적으로 수정되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "403", description = "댓글 수정 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 댓글 수정에 실패했습니다.")
+        }
+    )
+    ResponseEntity<ResponseWrapper<Void>> updateComment(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 ID") @PathVariable Long postId,
+        @Parameter(description = "댓글 ID") @PathVariable Long commentId,
+        @Parameter(description = "댓글 수정 요청") @RequestBody CommentUpdateRequest request);
+
+    @Operation(
+        summary = "게시글 댓글 삭제",
+        description = """
+            댓글 작성자가 자신의 댓글을 삭제합니다.
+            
+            **권한:**
+            - 댓글 작성자만 삭제 가능
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "댓글이 성공적으로 삭제되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "403", description = "댓글 삭제 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "해당 모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 댓글 삭제에 실패했습니다.")
+        }
+    )
+    ResponseEntity<ResponseWrapper<Void>> deleteComment(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 ID") @PathVariable Long postId,
+        @Parameter(description = "댓글 ID") @PathVariable Long commentId);
 }

--- a/src/main/java/site/festifriends/domain/comment/controller/CommentApi.java
+++ b/src/main/java/site/festifriends/domain/comment/controller/CommentApi.java
@@ -1,0 +1,45 @@
+package site.festifriends.domain.comment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.comment.dto.CommentListCursorResponse;
+import site.festifriends.domain.comment.dto.CommentListRequest;
+
+@Tag(name = "Comment", description = "게시글 댓글 관련 API")
+public interface CommentApi {
+
+    @Operation(
+        summary = "게시글 댓글 목록 조회",
+        description = """
+            특정 게시글의 댓글 목록을 커서 기반 페이지네이션으로 조회합니다.
+            
+            **요청 파라미터:**
+            - cursor: 이전 응답에서 받은 커서값, 없으면 첫 페이지 조회
+            - size: 한 번에 가져올 댓글 개수, 기본값 20
+            
+            **응답:**
+            - 댓글 목록은 작성 시간 순으로 정렬됩니다.
+            - 각 댓글에는 작성자 정보, 내용, 작성 시간, 신고 여부 등이 포함됩니다.
+            - 현재 사용자가 작성한 댓글인지 여부(isMine)도 포함됩니다.
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "댓글 목록을 불러오는데 성공하였습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "해당 모임에 속한 회원만 조회 가능"),
+            @ApiResponse(responseCode = "404", description = "모임 또는 게시글을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    ResponseEntity<CommentListCursorResponse> getCommentsByPostId(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 ID") @PathVariable Long postId,
+        @Parameter(description = "요청 파라미터 (cursor, size)") CommentListRequest request);
+}

--- a/src/main/java/site/festifriends/domain/comment/controller/CommentController.java
+++ b/src/main/java/site/festifriends/domain/comment/controller/CommentController.java
@@ -3,9 +3,11 @@ package site.festifriends.domain.comment.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +18,7 @@ import site.festifriends.domain.comment.dto.CommentCreateRequest;
 import site.festifriends.domain.comment.dto.CommentListCursorResponse;
 import site.festifriends.domain.comment.dto.CommentListRequest;
 import site.festifriends.domain.comment.dto.CommentResponse;
+import site.festifriends.domain.comment.dto.CommentUpdateRequest;
 import site.festifriends.domain.comment.service.CommentService;
 
 @RestController
@@ -57,5 +60,32 @@ public class CommentController implements CommentApi {
         commentService.createComment(groupId, postId, user.getMemberId(), request);
 
         return ResponseEntity.ok(ResponseWrapper.success("댓글이 성공적으로 등록되었습니다."));
+    }
+
+    @Override
+    @PutMapping("/{groupId}/posts/{postId}/comments/{commentId}")
+    public ResponseEntity<ResponseWrapper<Void>> updateComment(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long groupId,
+        @PathVariable Long postId,
+        @PathVariable Long commentId,
+        @RequestBody CommentUpdateRequest request
+    ) {
+        commentService.updateComment(groupId, postId, commentId, user.getMemberId(), request);
+
+        return ResponseEntity.ok(ResponseWrapper.success("댓글이 성공적으로 수정되었습니다."));
+    }
+
+    @Override
+    @DeleteMapping("/{groupId}/posts/{postId}/comments/{commentId}")
+    public ResponseEntity<ResponseWrapper<Void>> deleteComment(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long groupId,
+        @PathVariable Long postId,
+        @PathVariable Long commentId
+    ) {
+        commentService.deleteComment(groupId, postId, commentId, user.getMemberId());
+
+        return ResponseEntity.ok(ResponseWrapper.success("댓글이 성공적으로 삭제되었습니다."));
     }
 }

--- a/src/main/java/site/festifriends/domain/comment/controller/CommentController.java
+++ b/src/main/java/site/festifriends/domain/comment/controller/CommentController.java
@@ -5,10 +5,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.comment.dto.CommentCreateRequest;
 import site.festifriends.domain.comment.dto.CommentListCursorResponse;
 import site.festifriends.domain.comment.dto.CommentListRequest;
 import site.festifriends.domain.comment.dto.CommentResponse;
@@ -40,5 +44,18 @@ public class CommentController implements CommentApi {
         );
 
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @PostMapping("/{groupId}/posts/{postId}/comments")
+    public ResponseEntity<ResponseWrapper<Void>> createComment(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long groupId,
+        @PathVariable Long postId,
+        @RequestBody CommentCreateRequest request
+    ) {
+        commentService.createComment(groupId, postId, user.getMemberId(), request);
+
+        return ResponseEntity.ok(ResponseWrapper.success("댓글이 성공적으로 등록되었습니다."));
     }
 }

--- a/src/main/java/site/festifriends/domain/comment/controller/CommentController.java
+++ b/src/main/java/site/festifriends/domain/comment/controller/CommentController.java
@@ -1,0 +1,44 @@
+package site.festifriends.domain.comment.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.comment.dto.CommentListCursorResponse;
+import site.festifriends.domain.comment.dto.CommentListRequest;
+import site.festifriends.domain.comment.dto.CommentResponse;
+import site.festifriends.domain.comment.service.CommentService;
+
+@RestController
+@RequestMapping("/api/v1/groups")
+@RequiredArgsConstructor
+public class CommentController implements CommentApi {
+
+    private final CommentService commentService;
+
+    @Override
+    @GetMapping("/{groupId}/posts/{postId}/comments")
+    public ResponseEntity<CommentListCursorResponse> getCommentsByPostId(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long groupId,
+        @PathVariable Long postId,
+        CommentListRequest request
+    ) {
+        CursorResponseWrapper<CommentResponse> commentResponse = commentService.getCommentsByPostId(
+            groupId, postId, user.getMemberId(), request);
+
+        CommentListCursorResponse response = CommentListCursorResponse.success(
+            commentResponse.getMessage(),
+            commentResponse.getData(),
+            commentResponse.getCursorId(),
+            commentResponse.getHasNext()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/site/festifriends/domain/comment/dto/CommentAuthorResponse.java
+++ b/src/main/java/site/festifriends/domain/comment/dto/CommentAuthorResponse.java
@@ -1,0 +1,22 @@
+package site.festifriends.domain.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.entity.Member;
+
+@Getter
+@Builder
+public class CommentAuthorResponse {
+
+    private Long id;
+    private String name;
+    private String profileImage;
+
+    public static CommentAuthorResponse from(Member member) {
+        return CommentAuthorResponse.builder()
+            .id(member.getId())
+            .name(member.getNickname())
+            .profileImage(member.getProfileImageUrl())
+            .build();
+    }
+}

--- a/src/main/java/site/festifriends/domain/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/site/festifriends/domain/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,19 @@
+package site.festifriends.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentCreateRequest {
+
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 500, message = "댓글은 500자 이하로 작성해주세요.")
+    private String content;
+
+    public CommentCreateRequest(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/site/festifriends/domain/comment/dto/CommentListCursorResponse.java
+++ b/src/main/java/site/festifriends/domain/comment/dto/CommentListCursorResponse.java
@@ -1,0 +1,38 @@
+package site.festifriends.domain.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.common.response.CursorResponseWrapper;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CommentListCursorResponse {
+
+    private int code;
+    private String message;
+    private List<CommentResponse> data;
+    private Long cursorId;
+    private boolean hasNext;
+
+    public static CommentListCursorResponse success(String message, List<CommentResponse> data, Long cursorId, boolean hasNext) {
+        return CommentListCursorResponse.builder()
+            .code(200)
+            .message(message)
+            .data(data)
+            .cursorId(cursorId)
+            .hasNext(hasNext)
+            .build();
+    }
+
+    public static CommentListCursorResponse empty(String message) {
+        return CommentListCursorResponse.builder()
+            .code(200)
+            .message(message)
+            .data(List.of())
+            .cursorId(null)
+            .hasNext(false)
+            .build();
+    }
+}

--- a/src/main/java/site/festifriends/domain/comment/dto/CommentListRequest.java
+++ b/src/main/java/site/festifriends/domain/comment/dto/CommentListRequest.java
@@ -1,0 +1,18 @@
+package site.festifriends.domain.comment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommentListRequest {
+
+    private Long cursor;
+    private Integer size;
+
+    public Long getCursorId() {
+        return cursor;
+    }
+}

--- a/src/main/java/site/festifriends/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/site/festifriends/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,46 @@
+package site.festifriends.domain.comment.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.entity.Comments;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentResponse {
+
+    private Long id;
+    private Long postId;
+    private CommentAuthorResponse author;
+    private String content;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("isReported")
+    private boolean isReported;
+
+    @JsonProperty("isMine")
+    private boolean isMine;
+
+    public static CommentResponse from(Comments comments) {
+        return from(comments, null);
+    }
+
+    public static CommentResponse from(Comments comments, Long currentUserId) {
+        boolean isMine = currentUserId != null && comments.isMine(currentUserId);
+
+        return CommentResponse.builder()
+            .id(comments.getId())
+            .postId(comments.getPost().getId())
+            .author(CommentAuthorResponse.from(comments.getAuthor()))
+            .content(comments.getContent())
+            .createdAt(comments.getCreatedAt())
+            .isReported(comments.isReported())
+            .isMine(isMine)
+            .build();
+    }
+}

--- a/src/main/java/site/festifriends/domain/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/site/festifriends/domain/comment/dto/CommentUpdateRequest.java
@@ -1,0 +1,19 @@
+package site.festifriends.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentUpdateRequest {
+
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 500, message = "댓글은 500자 이하로 작성해주세요.")
+    private String content;
+
+    public CommentUpdateRequest(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/site/festifriends/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/site/festifriends/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package site.festifriends.domain.comment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.Comments;
+
+public interface CommentRepository extends JpaRepository<Comments, Long>, CommentRepositoryCustom {
+
+    /**
+     * 특정 게시글의 댓글 수 조회
+     */
+    long countByPostIdAndDeletedIsNull(Long postId);
+}

--- a/src/main/java/site/festifriends/domain/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,13 @@
+package site.festifriends.domain.comment.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import site.festifriends.entity.Comments;
+
+public interface CommentRepositoryCustom {
+
+    /**
+     * 게시글의 댓글 목록을 커서 기반 페이지네이션으로 조회
+     */
+    Slice<Comments> findCommentsByPostIdWithSlice(Long postId, Long cursorId, Pageable pageable);
+}

--- a/src/main/java/site/festifriends/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/comment/repository/CommentRepositoryImpl.java
@@ -1,0 +1,46 @@
+package site.festifriends.domain.comment.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import site.festifriends.entity.Comments;
+
+import java.util.List;
+
+import static site.festifriends.entity.QComments.comments;
+
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Comments> findCommentsByPostIdWithSlice(Long postId, Long cursorId, Pageable pageable) {
+        List<Comments> commentsList = queryFactory
+            .selectFrom(comments)
+            .leftJoin(comments.author).fetchJoin()
+            .where(
+                comments.post.id.eq(postId),
+                comments.deleted.isNull(),
+                cursorCondition(cursorId)
+            )
+            .orderBy(comments.id.asc())
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        boolean hasNext = false;
+        if (commentsList.size() > pageable.getPageSize()) {
+            commentsList.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(commentsList, pageable, hasNext);
+    }
+
+    private BooleanExpression cursorCondition(Long cursorId) {
+        return cursorId != null ? comments.id.gt(cursorId) : null;
+    }
+}

--- a/src/main/java/site/festifriends/domain/comment/service/CommentService.java
+++ b/src/main/java/site/festifriends/domain/comment/service/CommentService.java
@@ -1,0 +1,82 @@
+package site.festifriends.domain.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.festifriends.common.exception.BusinessException;
+import site.festifriends.common.exception.ErrorCode;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.application.repository.ApplicationRepository;
+import site.festifriends.domain.comment.dto.CommentListRequest;
+import site.festifriends.domain.comment.dto.CommentResponse;
+import site.festifriends.domain.comment.repository.CommentRepository;
+import site.festifriends.domain.group.repository.GroupRepository;
+import site.festifriends.domain.post.repository.PostRepository;
+import site.festifriends.entity.Comments;
+import site.festifriends.entity.Group;
+import site.festifriends.entity.Post;
+import site.festifriends.entity.enums.Role;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final GroupRepository groupRepository;
+    private final ApplicationRepository applicationRepository;
+
+    /**
+     * 게시글의 댓글 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public CursorResponseWrapper<CommentResponse> getCommentsByPostId(Long groupId, Long postId, Long memberId, CommentListRequest request) {
+        Group group = groupRepository.findById(groupId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
+
+        Post post = postRepository.findById(postId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."));
+
+        if (!post.getGroup().getId().equals(groupId)) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "해당 모임에 속한 게시글이 아닙니다.");
+        }
+
+        boolean isMember = applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.MEMBER) ||
+            applicationRepository.existsByGroupIdAndMemberIdAndRole(groupId, memberId, Role.HOST);
+
+        if (!isMember) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "해당 모임에 속한 회원만 댓글을 조회할 수 있습니다.");
+        }
+
+        Long cursorId = request.getCursorId();
+        int size = request.getSize() != null ? request.getSize() : 20;
+        PageRequest pageable = PageRequest.of(0, size);
+
+        Slice<Comments> commentSlice = commentRepository.findCommentsByPostIdWithSlice(postId, cursorId, pageable);
+
+        List<CommentResponse> commentResponses = commentSlice.getContent().stream()
+            .map(comment -> CommentResponse.from(comment, memberId))
+            .collect(Collectors.toList());
+
+        if (commentResponses.isEmpty()) {
+            return CursorResponseWrapper.empty("댓글 목록이 정상적으로 조회되었습니다.");
+        }
+
+        Long nextCursorId = null;
+        if (commentSlice.hasNext()) {
+            nextCursorId = commentResponses.get(commentResponses.size() - 1).getId();
+        }
+
+        return CursorResponseWrapper.success(
+            "댓글 목록을 불러오는데 성공하였습니다.",
+            commentResponses,
+            nextCursorId,
+            commentSlice.hasNext()
+        );
+    }
+}

--- a/src/main/java/site/festifriends/domain/group/controller/GroupApi.java
+++ b/src/main/java/site/festifriends/domain/group/controller/GroupApi.java
@@ -30,6 +30,14 @@ public interface GroupApi {
         description = """
             해당 공연의 모임 목록을 조회합니다.
             
+            검색 및 필터 기능:
+            - category: 모임 카테고리 필터 (COMPANION, RIDE_SHARE, ROOM_SHARE)
+            - startDate: 모임 시작 날짜 이후 필터 (yyyy-MM-dd 형식)
+            - endDate: 모임 종료 날짜 이전 필터 (yyyy-MM-dd 형식)
+            - location: 지역 필터 (부분 일치)
+            - gender: 성별 필터 (MALE, FEMALE, ALL)
+            - sort: 정렬 기준 (date_asc: 일자 빠른순, date_desc: 일자 먼순)
+            
             로그인한 사용자인 경우 모임 찜 여부도 조회됩니다.
             로그인하지 않은 사용자인 경우 찜 여부는 모두 false로 반환됩니다.
             """
@@ -38,6 +46,12 @@ public interface GroupApi {
     ResponseEntity<ResponseWrapper<PerformanceGroupsData>> getGroupsByPerformanceId(
         @AuthenticationPrincipal UserDetailsImpl user,
         @Parameter(description = "공연 ID") @PathVariable Long performanceId,
+        @Parameter(description = "카테고리 필터") @RequestParam(required = false) site.festifriends.entity.enums.GroupCategory category,
+        @Parameter(description = "시작 날짜 (yyyy-MM-dd)") @RequestParam(required = false) String startDate,
+        @Parameter(description = "종료 날짜 (yyyy-MM-dd)") @RequestParam(required = false) String endDate,
+        @Parameter(description = "지역 필터") @RequestParam(required = false) String location,
+        @Parameter(description = "성별 필터") @RequestParam(required = false) site.festifriends.entity.enums.Gender gender,
+        @Parameter(description = "정렬 기준 (date_asc, date_desc)") @RequestParam(required = false, defaultValue = "date_desc") String sort,
         @Parameter(description = "페이지 번호 (기본값: 1)") @RequestParam(defaultValue = "1") Integer page,
         @Parameter(description = "한 페이지당 항목 수 (기본값: 20)") @RequestParam(defaultValue = "20") Integer size
     );

--- a/src/main/java/site/festifriends/domain/group/controller/GroupApi.java
+++ b/src/main/java/site/festifriends/domain/group/controller/GroupApi.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.application.dto.ApplicationRequest;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.group.dto.GroupCreateRequest;
 import site.festifriends.domain.group.dto.GroupDetailResponse;
 import site.festifriends.domain.group.dto.GroupMembersResponse;
 import site.festifriends.domain.group.dto.GroupUpdateRequest;
@@ -24,6 +25,35 @@ import site.festifriends.domain.group.dto.UpdateMemberRoleRequest;
 
 @Tag(name = "Group", description = "모임 관련 API")
 public interface GroupApi {
+
+    @Operation(
+        summary = "모임 개설",
+        description = """
+            새로운 모임을 개설합니다.
+            
+            **요청 파라미터:**
+            - performanceId: 관련 공연 ID (필수)
+            - title: 모임 제목 (필수, 최대 100자)
+            - category: 모임 카테고리 (필수, "같이 동행"/"같이 탑승"/"같이 숙박")
+            - gender: 성별 제한 (필수, MALE/FEMALE/ALL)
+            - startAge, endAge: 연령 제한 (필수, 1-100)
+            - location: 모임 장소 (필수, 최대 200자)
+            - startDate, endDate: 모임 시작/종료 시간 (필수)
+            - maxMembers: 최대 인원 (필수, 2-50명)
+            - description: 모임 설명 (필수, 최대 500자)
+            - hashtag: 해시태그 (선택, 최대 10개)
+            """,
+        responses = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "모임이 성공적으로 개설되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류로 인해 모임 개설에 실패했습니다.")
+        }
+    )
+    @PostMapping("/api/v1/groups")
+    ResponseEntity<ResponseWrapper<Void>> createGroup(
+        @Valid @RequestBody GroupCreateRequest request,
+        @AuthenticationPrincipal UserDetailsImpl user
+    );
 
     @Operation(
         summary = "공연 모임 목록 조회",

--- a/src/main/java/site/festifriends/domain/group/controller/GroupController.java
+++ b/src/main/java/site/festifriends/domain/group/controller/GroupController.java
@@ -15,6 +15,7 @@ import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.application.dto.ApplicationRequest;
 import site.festifriends.domain.application.service.ApplicationService;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.group.dto.GroupCreateRequest;
 import site.festifriends.domain.group.dto.GroupDetailResponse;
 import site.festifriends.domain.group.dto.GroupMembersResponse;
 import site.festifriends.domain.group.dto.GroupUpdateRequest;
@@ -28,6 +29,17 @@ public class GroupController implements GroupApi {
 
     private final GroupService groupService;
     private final ApplicationService applicationService;
+
+    @Override
+    @PostMapping("/api/v1/groups")
+    public ResponseEntity<ResponseWrapper<Void>> createGroup(
+        @RequestBody GroupCreateRequest request,
+        @AuthenticationPrincipal UserDetailsImpl user
+    ) {
+        groupService.createGroup(request, user.getMemberId());
+
+        return ResponseEntity.ok(ResponseWrapper.success("모임이 성공적으로 개설되었습니다."));
+    }
 
     @Override
     @GetMapping("/api/v1/performances/{performanceId}/groups")

--- a/src/main/java/site/festifriends/domain/group/controller/GroupController.java
+++ b/src/main/java/site/festifriends/domain/group/controller/GroupController.java
@@ -35,12 +35,19 @@ public class GroupController implements GroupApi {
         (
             @AuthenticationPrincipal UserDetailsImpl user,
             @PathVariable Long performanceId,
-            Integer page,
-            Integer size
+            @RequestParam(required = false) site.festifriends.entity.enums.GroupCategory category,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(required = false) String location,
+            @RequestParam(required = false) site.festifriends.entity.enums.Gender gender,
+            @RequestParam(required = false, defaultValue = "date_desc") String sort,
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "20") Integer size
         ) {
 
         Long memberId = user != null ? user.getMemberId() : null;
-        PerformanceGroupsData data = groupService.getGroupsByPerformanceId(performanceId, page, size, memberId);
+        PerformanceGroupsData data = groupService.getGroupsByPerformanceId(
+            performanceId, category, startDate, endDate, location, gender, sort, page, size, memberId);
 
         return ResponseEntity.ok(ResponseWrapper.success("요청이 성공적으로 처리되었습니다.", data));
     }

--- a/src/main/java/site/festifriends/domain/group/dto/GroupCreateRequest.java
+++ b/src/main/java/site/festifriends/domain/group/dto/GroupCreateRequest.java
@@ -1,0 +1,84 @@
+package site.festifriends.domain.group.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.festifriends.entity.enums.Gender;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GroupCreateRequest {
+
+    @NotBlank(message = "공연 ID는 필수입니다.")
+    private String performanceId;
+
+    @NotBlank(message = "모임 제목은 필수입니다.")
+    @Size(max = 100, message = "모임 제목은 100자 이하로 입력해주세요.")
+    private String title;
+
+    @NotBlank(message = "카테고리는 필수입니다.")
+    private String category;
+
+    @NotNull(message = "성별 제한은 필수입니다.")
+    private Gender gender;
+
+    @NotNull(message = "시작 연령은 필수입니다.")
+    @Min(value = 1, message = "시작 연령은 1 이상이어야 합니다.")
+    @Max(value = 100, message = "시작 연령은 100 이하여야 합니다.")
+    private Integer startAge;
+
+    @NotNull(message = "종료 연령은 필수입니다.")
+    @Min(value = 1, message = "종료 연령은 1 이상이어야 합니다.")
+    @Max(value = 100, message = "종료 연령은 100 이하여야 합니다.")
+    private Integer endAge;
+
+    @NotBlank(message = "모임 장소는 필수입니다.")
+    @Size(max = 200, message = "모임 장소는 200자 이하로 입력해주세요.")
+    private String location;
+
+    @NotNull(message = "시작 시간은 필수입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    private LocalDateTime startDate;
+
+    @NotNull(message = "종료 시간은 필수입니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    private LocalDateTime endDate;
+
+    @NotNull(message = "최대 인원은 필수입니다.")
+    @Min(value = 2, message = "최대 인원은 2명 이상이어야 합니다.")
+    @Max(value = 50, message = "최대 인원은 50명 이하여야 합니다.")
+    private Integer maxMembers;
+
+    @NotBlank(message = "모임 설명은 필수입니다.")
+    @Size(max = 500, message = "모임 설명은 500자 이하로 입력해주세요.")
+    private String description;
+
+    @Size(max = 10, message = "해시태그는 최대 10개까지 가능합니다.")
+    private List<String> hashtag;
+
+    public GroupCreateRequest(String performanceId, String title, String category, Gender gender,
+        Integer startAge, Integer endAge, String location,
+        LocalDateTime startDate, LocalDateTime endDate, Integer maxMembers,
+        String description, List<String> hashtag) {
+        this.performanceId = performanceId;
+        this.title = title;
+        this.category = category;
+        this.gender = gender;
+        this.startAge = startAge;
+        this.endAge = endAge;
+        this.location = location;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.maxMembers = maxMembers;
+        this.description = description;
+        this.hashtag = hashtag;
+    }
+}

--- a/src/main/java/site/festifriends/domain/group/dto/GroupResponse.java
+++ b/src/main/java/site/festifriends/domain/group/dto/GroupResponse.java
@@ -27,6 +27,9 @@ public class GroupResponse {
     @JsonProperty("isFavorite")
     private boolean isFavorite;
 
+    @JsonProperty("isHost")
+    private boolean isHost;
+
     private Host host;
 
     @Getter
@@ -35,5 +38,6 @@ public class GroupResponse {
         private String hostId;
         private String name;
         private Double rating;
+        private String profileImage;
     }
 }

--- a/src/main/java/site/festifriends/domain/group/repository/GroupRepository.java
+++ b/src/main/java/site/festifriends/domain/group/repository/GroupRepository.java
@@ -1,13 +1,14 @@
 package site.festifriends.domain.group.repository;
 
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import site.festifriends.entity.Group;
-
-import java.util.List;
+import site.festifriends.entity.enums.Gender;
+import site.festifriends.entity.enums.GroupCategory;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
@@ -16,4 +17,43 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     @Query("SELECT COUNT(g) FROM Group g WHERE g.performance.id = :performanceId AND g.deleted IS NULL")
     Long countByPerformanceId(@Param("performanceId") Long performanceId);
+
+    @Query("""
+        SELECT g FROM Group g 
+        WHERE g.performance.id = :performanceId 
+        AND g.deleted IS NULL
+        AND (:category IS NULL OR g.gatherType = :category)
+        AND (:startDate IS NULL OR g.startDate >= :startDate)
+        AND (:endDate IS NULL OR g.endDate <= :endDate)
+        AND (:location IS NULL OR g.location LIKE %:location%)
+        AND (:gender IS NULL OR g.genderType = :gender)
+        """)
+    Page<Group> findByPerformanceIdWithFilters(
+        @Param("performanceId") Long performanceId,
+        @Param("category") GroupCategory category,
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        @Param("location") String location,
+        @Param("gender") Gender gender,
+        Pageable pageable
+    );
+
+    @Query("""
+        SELECT COUNT(g) FROM Group g 
+        WHERE g.performance.id = :performanceId 
+        AND g.deleted IS NULL
+        AND (:category IS NULL OR g.gatherType = :category)
+        AND (:startDate IS NULL OR g.startDate >= :startDate)
+        AND (:endDate IS NULL OR g.endDate <= :endDate)
+        AND (:location IS NULL OR g.location LIKE %:location%)
+        AND (:gender IS NULL OR g.genderType = :gender)
+        """)
+    Long countByPerformanceIdWithFilters(
+        @Param("performanceId") Long performanceId,
+        @Param("category") GroupCategory category,
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        @Param("location") String location,
+        @Param("gender") Gender gender
+    );
 }

--- a/src/main/java/site/festifriends/domain/group/service/GroupService.java
+++ b/src/main/java/site/festifriends/domain/group/service/GroupService.java
@@ -222,7 +222,8 @@ public class GroupService {
                 hostMap.get(group.getId()),
                 bookmarkedGroupIds.contains(group.getId()),
                 finalMemberCountMap,
-                finalHostRatingMap
+                finalHostRatingMap,
+                memberId
             ))
             .collect(Collectors.toList());
 
@@ -515,17 +516,22 @@ public class GroupService {
     }
 
     private GroupResponse convertToGroupResponse(Group group, MemberGroup hostMemberGroup, boolean isFavorite,
-        Map<Long, Long> memberCountMap, Map<Long, Double> hostRatingMap) {
+        Map<Long, Long> memberCountMap, Map<Long, Double> hostRatingMap, Long memberId) {
         // 호스트 정보 설정
         GroupResponse.Host host = null;
+        boolean isHost = false;
+
         if (hostMemberGroup != null) {
             Long hostId = hostMemberGroup.getMember().getId();
             Double hostRating = hostRatingMap.getOrDefault(hostId, 0.0);
+
+            isHost = memberId != null && memberId.equals(hostId);
 
             host = GroupResponse.Host.builder()
                 .hostId(hostId.toString())
                 .name(hostMemberGroup.getMember().getNickname())
                 .rating(hostRating)
+                .profileImage(hostMemberGroup.getMember().getProfileImageUrl())
                 .build();
         }
 
@@ -545,6 +551,7 @@ public class GroupService {
             .maxMembers(group.getCount())
             .hashtag(group.getHashTags())
             .isFavorite(isFavorite)
+            .isHost(isHost)
             .host(host)
             .build();
     }

--- a/src/main/java/site/festifriends/domain/member/repository/BookmarkRepository.java
+++ b/src/main/java/site/festifriends/domain/member/repository/BookmarkRepository.java
@@ -1,8 +1,15 @@
 package site.festifriends.domain.member.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.festifriends.entity.Bookmark;
+import site.festifriends.entity.enums.BookmarkType;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
+    Optional<Bookmark> findByMemberIdAndTypeAndTargetId(Long memberId, BookmarkType type, Long targetId);
+
+    boolean existsByMemberIdAndTypeAndTargetId(Long memberId, BookmarkType type, Long targetId);
+
+    void deleteByMemberIdAndTypeAndTargetId(Long memberId, BookmarkType type, Long targetId);
 }

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
@@ -18,6 +18,7 @@ import site.festifriends.domain.performance.dto.PerformanceFavoriteResponse;
 import site.festifriends.domain.performance.dto.PerformanceResponse;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.domain.performance.dto.PerformanceSearchResponse;
+import site.festifriends.domain.review.dto.RecentReviewResponse;
 
 @Tag(name = "Performance", description = "공연 관련 API")
 public interface PerformanceApi {
@@ -123,4 +124,26 @@ public interface PerformanceApi {
     ResponseEntity<ResponseWrapper<List<PerformanceResponse>>> getTopGroupsUpcomingPerformances(
         @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
     );
+
+    @Operation(
+        summary = "최근 올라온 리뷰 TOP 5 조회",
+        description = """
+            최근 작성된 리뷰를 기준으로 상위 5개 리뷰를 조회합니다.
+            
+            **조건:**
+            - 작성일시(createdAt) 기준 최신순 정렬
+            - 같은 모임의 리뷰여도 상관없이 개별 리뷰 5개 반환
+            
+            **응답 정보:**
+            - 각 리뷰의 모임 정보 (제목, 카테고리, 날짜)
+            - 관련 공연 정보 (제목, 포스터)
+            - 리뷰 상세 정보 (평점, 내용, 태그, 작성일시)
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "최근 올라온 리뷰 top5 조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    @GetMapping("/recent-reviews")
+    ResponseEntity<ResponseWrapper<List<RecentReviewResponse>>> getRecentReviews();
 }

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
@@ -2,14 +2,18 @@ package site.festifriends.domain.performance.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.performance.dto.PerformanceFavoriteRequest;
+import site.festifriends.domain.performance.dto.PerformanceFavoriteResponse;
 import site.festifriends.domain.performance.dto.PerformanceResponse;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.domain.performance.dto.PerformanceSearchResponse;
@@ -18,39 +22,61 @@ import site.festifriends.domain.performance.dto.PerformanceSearchResponse;
 public interface PerformanceApi {
 
     @Operation(
-            summary = "공연 검색",
-            description = """
-                    공연을 검색합니다.
-
-                    **검색 필터:**
-                    - title: 공연명 검색
-                    - location: 지역 검색
-                    - visit: 국내/내한 여부 (국내, 내한)
-                    - startDate: 검색 시작 날짜 (yyyy-MM-dd)
-                    - endDate: 검색 종료 날짜 (yyyy-MM-dd)
-
-                    **정렬 옵션:**
-                    - title_asc: 이름 가나다순 (기본값)
-                    - title_desc: 이름 역순
-                    - date_asc: 일자 빠른순
-                    - date_desc: 일자 먼순
-                    - group_count_desc: 모임개수 많은 순
-                    - group_count_asc: 모임개수 적은 순
-                    """
+        summary = "공연 검색",
+        description = """
+            공연을 검색합니다.
+            
+            **검색 필터:**
+            - title: 공연명 검색
+            - location: 지역 검색
+            - visit: 국내/내한 여부 (국내, 내한)
+            - startDate: 검색 시작 날짜 (yyyy-MM-dd)
+            - endDate: 검색 종료 날짜 (yyyy-MM-dd)
+            
+            **정렬 옵션:**
+            - title_asc: 이름 가나다순 (기본값)
+            - title_desc: 이름 역순
+            - date_asc: 일자 빠른순
+            - date_desc: 일자 먼순
+            - group_count_desc: 모임개수 많은 순
+            - group_count_asc: 모임개수 적은 순
+            """
     )
     @GetMapping
     ResponseEntity<PerformanceSearchResponse> searchPerformances(
-            @Parameter(description = "검색 조건") PerformanceSearchRequest request,
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
+        @Parameter(description = "검색 조건") PerformanceSearchRequest request,
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
     );
 
     @Operation(
-            summary = "공연 상세 조회",
-            description = "공연 ID로 공연 상세 정보를 조회합니다."
+        summary = "공연 상세 조회",
+        description = "공연 ID로 공연 상세 정보를 조회합니다."
     )
     @GetMapping("/{performanceId}")
     ResponseEntity<ResponseWrapper<PerformanceResponse>> getPerformanceDetail(
-            @Parameter(description = "공연 ID") @PathVariable Long performanceId,
-            @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
+        @Parameter(description = "공연 ID") @PathVariable Long performanceId,
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
+    );
+
+    @Operation(
+        summary = "공연 찜하기/취소",
+        description = """
+            공연을 찜하거나 찜을 취소합니다.
+            
+            **요청:**
+            - isLiked: true(찜하기), false(찜 취소)
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "공연을 찜했습니다. / 공연을 찜 취소했습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "404", description = "공연을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    @PatchMapping("/{performanceId}/favorites")
+    ResponseEntity<ResponseWrapper<PerformanceFavoriteResponse>> togglePerformanceFavorite(
+        @Parameter(description = "공연 ID") @PathVariable Long performanceId,
+        @Parameter(description = "찜하기 요청") @RequestBody PerformanceFavoriteRequest request,
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
     );
 }

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -77,6 +78,27 @@ public interface PerformanceApi {
     ResponseEntity<ResponseWrapper<PerformanceFavoriteResponse>> togglePerformanceFavorite(
         @Parameter(description = "공연 ID") @PathVariable Long performanceId,
         @Parameter(description = "찜하기 요청") @RequestBody PerformanceFavoriteRequest request,
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
+    );
+
+    @Operation(
+        summary = "찜한 수가 많은 공연 TOP5 조회",
+        description = """
+            찜한 수가 많은 공연 TOP5를 조회합니다.
+            
+            **조건:**
+            - 아직 시작하지 않은 공연만 대상
+            - 찜 수가 많은 순으로 정렬
+            - 찜 수가 같은 경우 제목 가나다순으로 정렬
+            - 최대 5개 공연 반환
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "요청이 성공적으로 처리되었습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    @GetMapping("/top-favorites")
+    ResponseEntity<ResponseWrapper<List<PerformanceResponse>>> getTopFavoriteUpcomingPerformances(
         @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
     );
 }

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceApi.java
@@ -101,4 +101,26 @@ public interface PerformanceApi {
     ResponseEntity<ResponseWrapper<List<PerformanceResponse>>> getTopFavoriteUpcomingPerformances(
         @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
     );
+
+    @Operation(
+        summary = "개설된 모임이 가장 많은 공연 TOP5 조회",
+        description = """
+            개설된 모임이 가장 많은 공연 TOP5를 조회합니다.
+            
+            **조건:**
+            - 아직 시작하지 않은 공연만 대상
+            - 모임 수가 많은 순으로 정렬
+            - 모임 수가 같은 경우 빠른 날짜순으로 정렬
+            - 날짜도 같은 경우 제목 가나다순으로 정렬
+            - 최대 5개 공연 반환
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "요청이 성공적으로 처리되었습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    @GetMapping("/top-groups")
+    ResponseEntity<ResponseWrapper<List<PerformanceResponse>>> getTopGroupsUpcomingPerformances(
+        @Parameter(hidden = true) @AuthenticationPrincipal UserDetailsImpl user
+    );
 }

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
@@ -18,6 +18,8 @@ import site.festifriends.domain.performance.dto.PerformanceResponse;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.domain.performance.dto.PerformanceSearchResponse;
 import site.festifriends.domain.performance.service.PerformanceService;
+import site.festifriends.domain.review.dto.RecentReviewResponse;
+import site.festifriends.domain.review.service.ReviewService;
 
 @RestController
 @RequestMapping("/api/v1/performances")
@@ -25,6 +27,7 @@ import site.festifriends.domain.performance.service.PerformanceService;
 public class PerformanceController implements PerformanceApi {
 
     private final PerformanceService performanceService;
+    private final ReviewService reviewService;
 
     @Override
     @GetMapping
@@ -74,6 +77,7 @@ public class PerformanceController implements PerformanceApi {
         return ResponseEntity.ok(response);
     }
 
+    @Override
     @GetMapping("/top-groups")
     public ResponseEntity<ResponseWrapper<List<PerformanceResponse>>> getTopGroupsUpcomingPerformances(
         @AuthenticationPrincipal UserDetailsImpl user) {
@@ -81,5 +85,15 @@ public class PerformanceController implements PerformanceApi {
         ResponseWrapper<List<PerformanceResponse>> response = performanceService.getTopGroupsUpcomingPerformances(
             memberId);
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/recent-reviews")
+    public ResponseEntity<ResponseWrapper<List<RecentReviewResponse>>> getRecentReviews() {
+        List<RecentReviewResponse> reviews = reviewService.getRecentReviews();
+
+        return ResponseEntity.ok(
+            ResponseWrapper.success("최근 올라온 리뷰 top5 조회 성공", reviews)
+        );
     }
 } 

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
@@ -73,4 +73,13 @@ public class PerformanceController implements PerformanceApi {
             memberId);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/top-groups")
+    public ResponseEntity<ResponseWrapper<List<PerformanceResponse>>> getTopGroupsUpcomingPerformances(
+        @AuthenticationPrincipal UserDetailsImpl user) {
+        Long memberId = user != null ? user.getMemberId() : null;
+        ResponseWrapper<List<PerformanceResponse>> response = performanceService.getTopGroupsUpcomingPerformances(
+            memberId);
+        return ResponseEntity.ok(response);
+    }
 } 

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
@@ -4,12 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.performance.dto.PerformanceFavoriteRequest;
+import site.festifriends.domain.performance.dto.PerformanceFavoriteResponse;
 import site.festifriends.domain.performance.dto.PerformanceResponse;
 import site.festifriends.domain.performance.dto.PerformanceSearchRequest;
 import site.festifriends.domain.performance.dto.PerformanceSearchResponse;
@@ -25,8 +28,8 @@ public class PerformanceController implements PerformanceApi {
     @Override
     @GetMapping
     public ResponseEntity<PerformanceSearchResponse> searchPerformances(
-            PerformanceSearchRequest request,
-            @AuthenticationPrincipal UserDetailsImpl user) {
+        PerformanceSearchRequest request,
+        @AuthenticationPrincipal UserDetailsImpl user) {
         Long memberId = user != null ? user.getMemberId() : null;
         PerformanceSearchResponse response = performanceService.searchPerformances(request, memberId);
         return ResponseEntity.ok(response);
@@ -35,10 +38,28 @@ public class PerformanceController implements PerformanceApi {
     @Override
     @GetMapping("/{performanceId}")
     public ResponseEntity<ResponseWrapper<PerformanceResponse>> getPerformanceDetail(
-            @PathVariable Long performanceId,
-            @AuthenticationPrincipal UserDetailsImpl user) {
+        @PathVariable Long performanceId,
+        @AuthenticationPrincipal UserDetailsImpl user) {
         Long memberId = user != null ? user.getMemberId() : null;
-        ResponseWrapper<PerformanceResponse> response = performanceService.getPerformanceDetail(performanceId, memberId);
+        ResponseWrapper<PerformanceResponse> response = performanceService.getPerformanceDetail(performanceId,
+            memberId);
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @PatchMapping("/{performanceId}/favorites")
+    public ResponseEntity<ResponseWrapper<PerformanceFavoriteResponse>> togglePerformanceFavorite(
+        @PathVariable Long performanceId,
+        @RequestBody PerformanceFavoriteRequest request,
+        @AuthenticationPrincipal UserDetailsImpl user
+    ) {
+        PerformanceFavoriteResponse response = performanceService.togglePerformanceFavorite(
+            performanceId, user.getMemberId(), request);
+
+        String message = Boolean.TRUE.equals(request.getIsLiked())
+            ? "공연을 찜했습니다."
+            : "공연을 찜 취소했습니다.";
+
+        return ResponseEntity.ok(ResponseWrapper.success(message, response));
     }
 } 

--- a/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/site/festifriends/domain/performance/controller/PerformanceController.java
@@ -1,5 +1,6 @@
 package site.festifriends.domain.performance.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -61,5 +62,15 @@ public class PerformanceController implements PerformanceApi {
             : "공연을 찜 취소했습니다.";
 
         return ResponseEntity.ok(ResponseWrapper.success(message, response));
+    }
+
+    @Override
+    @GetMapping("/top-favorites")
+    public ResponseEntity<ResponseWrapper<List<PerformanceResponse>>> getTopFavoriteUpcomingPerformances(
+        @AuthenticationPrincipal UserDetailsImpl user) {
+        Long memberId = user != null ? user.getMemberId() : null;
+        ResponseWrapper<List<PerformanceResponse>> response = performanceService.getTopFavoriteUpcomingPerformances(
+            memberId);
+        return ResponseEntity.ok(response);
     }
 } 

--- a/src/main/java/site/festifriends/domain/performance/dto/PerformanceFavoriteRequest.java
+++ b/src/main/java/site/festifriends/domain/performance/dto/PerformanceFavoriteRequest.java
@@ -1,0 +1,15 @@
+package site.festifriends.domain.performance.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PerformanceFavoriteRequest {
+
+    private Boolean isLiked;
+
+    public PerformanceFavoriteRequest(Boolean isLiked) {
+        this.isLiked = isLiked;
+    }
+}

--- a/src/main/java/site/festifriends/domain/performance/dto/PerformanceFavoriteResponse.java
+++ b/src/main/java/site/festifriends/domain/performance/dto/PerformanceFavoriteResponse.java
@@ -1,0 +1,19 @@
+package site.festifriends.domain.performance.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PerformanceFavoriteResponse {
+
+    private String performanceId;
+    private Boolean isLiked;
+
+    public static PerformanceFavoriteResponse of(Long performanceId, Boolean isLiked) {
+        return PerformanceFavoriteResponse.builder()
+            .performanceId(performanceId.toString())
+            .isLiked(isLiked)
+            .build();
+    }
+}

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
@@ -20,4 +20,6 @@ public interface PerformanceRepositoryCustom {
     Map<Long, Boolean> findIsLikedByPerformanceIds(List<Long> performanceIds, Long memberId);
 
     List<Performance> findTopFavoriteUpcomingPerformances(int limit);
+
+    List<Performance> findTopGroupsUpcomingPerformances(int limit);
 } 

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryCustom.java
@@ -18,4 +18,6 @@ public interface PerformanceRepositoryCustom {
     Map<Long, Integer> getGroupCountsByPerformanceIds(List<Long> performanceIds);
 
     Map<Long, Boolean> findIsLikedByPerformanceIds(List<Long> performanceIds, Long memberId);
+
+    List<Performance> findTopFavoriteUpcomingPerformances(int limit);
 } 

--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepositoryImpl.java
@@ -262,6 +262,54 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
         return topPerformanceIds.stream()
             .map(performanceMap::get)
             .filter(performance -> performance != null)
-            .collect(Collectors.toList());
+            .toList();
+    }
+
+    @Override
+    public List<Performance> findTopGroupsUpcomingPerformances(int limit) {
+        QPerformance p = QPerformance.performance;
+        QGroup g = QGroup.group;
+        QPerformanceImage pi = QPerformanceImage.performanceImage;
+
+        LocalDateTime now = LocalDateTime.now();
+
+        List<Long> topPerformanceIds = queryFactory
+            .select(p.id)
+            .from(p)
+            .leftJoin(g).on(g.performance.id.eq(p.id).and(g.deleted.isNull()))
+            .where(
+                p.startDate.gt(now),
+                notDeleted()
+            )
+            .groupBy(p.id)
+            .orderBy(
+                g.count().desc(),     // 모임 수가 많은 순
+                p.startDate.asc(),    // 모임 수가 같으면 빠른 날짜순
+                p.title.asc()         // 날짜도 같으면 제목순
+            )
+            .limit(limit)
+            .fetch();
+
+        if (topPerformanceIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Performance> performances = queryFactory
+            .selectFrom(p)
+            .leftJoin(p.imgs, pi).fetchJoin()
+            .where(
+                p.id.in(topPerformanceIds),
+                notDeleted()
+            )
+            .distinct()
+            .fetch();
+
+        Map<Long, Performance> performanceMap = performances.stream()
+            .collect(Collectors.toMap(Performance::getId, performance -> performance));
+
+        return topPerformanceIds.stream()
+            .map(performanceMap::get)
+            .filter(performance -> performance != null)
+            .toList();
     }
 } 

--- a/src/main/java/site/festifriends/domain/performance/service/PerformanceService.java
+++ b/src/main/java/site/festifriends/domain/performance/service/PerformanceService.java
@@ -218,4 +218,43 @@ public class PerformanceService {
         boolean finalLikedState = Boolean.TRUE.equals(request.getIsLiked());
         return PerformanceFavoriteResponse.of(performanceId, finalLikedState);
     }
+
+    /**
+     * 찜한 수가 많은 공연 TOP5 조회 (아직 시작하지 않은 공연만)
+     */
+    public ResponseWrapper<List<PerformanceResponse>> getTopFavoriteUpcomingPerformances(Long memberId) {
+        List<Performance> topPerformances = performanceRepository.findTopFavoriteUpcomingPerformances(5);
+
+        if (topPerformances.isEmpty()) {
+            return ResponseWrapper.success("요청이 성공적으로 처리되었습니다.", List.of());
+        }
+
+        topPerformances.forEach(performance -> {
+            performance.getCast().size();
+            performance.getCrew().size();
+            performance.getProductionCompany().size();
+            performance.getAgency().size();
+            performance.getHost().size();
+            performance.getOrganizer().size();
+            performance.getPrice().size();
+            performance.getTime().size();
+            performance.getImgs().size();
+        });
+
+        List<Long> performanceIds = topPerformances.stream()
+            .map(Performance::getId)
+            .collect(Collectors.toList());
+
+        Map<Long, Long> groupCountMap = performanceRepository.findGroupCountsByPerformanceIds(performanceIds);
+
+        Map<Long, Long> favoriteCountMap = performanceRepository.findFavoriteCountsByPerformanceIds(performanceIds);
+
+        Map<Long, Boolean> isLikedMap = performanceRepository.findIsLikedByPerformanceIds(performanceIds, memberId);
+
+        List<PerformanceResponse> performanceResponses = topPerformances.stream()
+            .map(performance -> convertToResponse(performance, groupCountMap, favoriteCountMap, isLikedMap))
+            .toList();
+
+        return ResponseWrapper.success("요청이 성공적으로 처리되었습니다.", performanceResponses);
+    }
 } 

--- a/src/main/java/site/festifriends/domain/performance/service/PerformanceService.java
+++ b/src/main/java/site/festifriends/domain/performance/service/PerformanceService.java
@@ -257,4 +257,43 @@ public class PerformanceService {
 
         return ResponseWrapper.success("요청이 성공적으로 처리되었습니다.", performanceResponses);
     }
+
+    /**
+     * 개설된 모임이 가장 많은 공연 TOP5 조회 (아직 시작하지 않은 공연만)
+     */
+    public ResponseWrapper<List<PerformanceResponse>> getTopGroupsUpcomingPerformances(Long memberId) {
+        List<Performance> topPerformances = performanceRepository.findTopGroupsUpcomingPerformances(5);
+
+        if (topPerformances.isEmpty()) {
+            return ResponseWrapper.success("요청이 성공적으로 처리되었습니다.", List.of());
+        }
+
+        topPerformances.forEach(performance -> {
+            performance.getCast().size();
+            performance.getCrew().size();
+            performance.getProductionCompany().size();
+            performance.getAgency().size();
+            performance.getHost().size();
+            performance.getOrganizer().size();
+            performance.getPrice().size();
+            performance.getTime().size();
+            performance.getImgs().size();
+        });
+
+        List<Long> performanceIds = topPerformances.stream()
+            .map(Performance::getId)
+            .collect(Collectors.toList());
+
+        Map<Long, Long> groupCountMap = performanceRepository.findGroupCountsByPerformanceIds(performanceIds);
+
+        Map<Long, Long> favoriteCountMap = performanceRepository.findFavoriteCountsByPerformanceIds(performanceIds);
+
+        Map<Long, Boolean> isLikedMap = performanceRepository.findIsLikedByPerformanceIds(performanceIds, memberId);
+
+        List<PerformanceResponse> performanceResponses = topPerformances.stream()
+            .map(performance -> convertToResponse(performance, groupCountMap, favoriteCountMap, isLikedMap))
+            .toList();
+
+        return ResponseWrapper.success("요청이 성공적으로 처리되었습니다.", performanceResponses);
+    }
 } 

--- a/src/main/java/site/festifriends/domain/post/controller/PostApi.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostApi.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import site.festifriends.common.response.ResponseWrapper;
@@ -17,6 +16,7 @@ import site.festifriends.domain.post.dto.PostListCursorResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
 import site.festifriends.domain.post.dto.PostPinRequest;
 import site.festifriends.domain.post.dto.PostReactionRequest;
+import site.festifriends.domain.post.dto.PostResponse;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
 import site.festifriends.domain.post.dto.PostUpdateRequest;
 
@@ -49,6 +49,28 @@ public interface PostApi {
         @AuthenticationPrincipal UserDetailsImpl user,
         @Parameter(description = "모임 ID") @PathVariable Long groupId,
         @Parameter(description = "요청 파라미터 (cursorId, size)") PostListRequest request);
+
+    @Operation(
+        summary = "모임 내 게시글 상세 조회",
+        description = """
+            모임 내 특정 게시글의 상세 정보를 조회합니다.
+            
+            **응답:**
+            - 게시글의 모든 정보(내용, 작성자, 이미지, 댓글 수, 반응 수 등)가 포함됩니다.
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글이 성공적으로 조회되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "해당 모임에 속한 회원만 조회 가능"),
+            @ApiResponse(responseCode = "404", description = "모임 또는 게시글을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    ResponseEntity<ResponseWrapper<PostResponse>> getPostDetail(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 ID") @PathVariable Long postId);
 
     @Operation(
         summary = "모임 내 게시글 등록",

--- a/src/main/java/site/festifriends/domain/post/controller/PostApi.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostApi.java
@@ -16,6 +16,7 @@ import site.festifriends.domain.post.dto.PostCreateResponse;
 import site.festifriends.domain.post.dto.PostListCursorResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
 import site.festifriends.domain.post.dto.PostPinRequest;
+import site.festifriends.domain.post.dto.PostReactionRequest;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
 import site.festifriends.domain.post.dto.PostUpdateRequest;
 
@@ -157,4 +158,35 @@ public interface PostApi {
         @Parameter(description = "모임 ID") @PathVariable Long groupId,
         @Parameter(description = "게시글 ID") @PathVariable Long postId,
         @Parameter(description = "게시글 고정/해제 정보") @RequestBody PostPinRequest request);
+
+    @Operation(
+        summary = "모임 내 게시글 반응 등록/취소",
+        description = """
+            모임 내 게시글에 반응을 등록하거나 취소합니다. 해당 모임에 속한 회원만 가능합니다.
+            
+            **요청 본문:**
+            - hasReactioned: 반응 여부 (true: 반응 등록, false: 반응 취소)
+            
+            **응답:**
+            - 반응 등록 시: "게시글에 반응이 등록되었습니다."
+            - 반응 취소 시: "게시글 반응이 취소되었습니다."
+            
+            **참고:**
+            - 한 회원당 하나의 게시글에 최대 1개의 반응만 가능합니다.
+            - 반응이 등록/취소될 때마다 게시글의 reactionCount가 자동으로 업데이트됩니다.
+            """,
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 반응이 성공적으로 처리되었습니다."),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "해당 모임에 속한 회원만 게시글에 반응할 수 있습니다."),
+            @ApiResponse(responseCode = "404", description = "해당 모임 또는 게시글을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류로 인해 게시글 반응 처리에 실패했습니다.")
+        }
+    )
+    ResponseEntity<ResponseWrapper<Void>> togglePostReaction(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Parameter(description = "모임 ID") @PathVariable Long groupId,
+        @Parameter(description = "게시글 ID") @PathVariable Long postId,
+        @Parameter(description = "게시글 반응 정보") @RequestBody PostReactionRequest request);
 }

--- a/src/main/java/site/festifriends/domain/post/controller/PostController.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostController.java
@@ -56,6 +56,18 @@ public class PostController implements PostApi {
     }
 
     @Override
+    @GetMapping("/{groupId}/posts/{postId}")
+    public ResponseEntity<ResponseWrapper<PostResponse>> getPostDetail(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long groupId,
+        @PathVariable Long postId
+    ) {
+        PostResponse response = postService.getPostDetail(groupId, postId, user.getMemberId());
+
+        return ResponseEntity.ok(ResponseWrapper.success("게시글이 성공적으로 조회되었습니다.", response));
+    }
+
+    @Override
     @PostMapping("/{groupId}/posts")
     public ResponseEntity<ResponseWrapper<PostCreateResponse>> createPost(
         @AuthenticationPrincipal UserDetailsImpl user,

--- a/src/main/java/site/festifriends/domain/post/controller/PostController.java
+++ b/src/main/java/site/festifriends/domain/post/controller/PostController.java
@@ -20,6 +20,7 @@ import site.festifriends.domain.post.dto.PostListCursorResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
 import site.festifriends.domain.post.dto.PostListResponse;
 import site.festifriends.domain.post.dto.PostPinRequest;
+import site.festifriends.domain.post.dto.PostReactionRequest;
 import site.festifriends.domain.post.dto.PostResponse;
 import site.festifriends.domain.post.dto.PostUpdateDeleteResponse;
 import site.festifriends.domain.post.dto.PostUpdateRequest;
@@ -104,6 +105,22 @@ public class PostController implements PostApi {
         String message = Boolean.TRUE.equals(request.getIsPinned())
             ? "게시글이 고정되었습니다."
             : "게시글 고정이 해제되었습니다.";
+
+        return ResponseEntity.ok(ResponseWrapper.success(message));
+    }
+
+    @PatchMapping("/{groupId}/posts/{postId}/reaction")
+    public ResponseEntity<ResponseWrapper<Void>> togglePostReaction(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long groupId,
+        @PathVariable Long postId,
+        @RequestBody PostReactionRequest request
+    ) {
+        postService.togglePostReaction(groupId, postId, user.getMemberId(), request);
+
+        String message = Boolean.TRUE.equals(request.getHasReactioned())
+            ? "게시글에 반응이 등록되었습니다."
+            : "게시글 반응이 취소되었습니다.";
 
         return ResponseEntity.ok(ResponseWrapper.success(message));
     }

--- a/src/main/java/site/festifriends/domain/post/dto/PostImageResponse.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostImageResponse.java
@@ -7,16 +7,16 @@ import site.festifriends.entity.PostImage;
 @Getter
 @Builder
 public class PostImageResponse {
-    
+
     private Long id;
     private String alt;
     private String src;
-    
+
     public static PostImageResponse from(PostImage image) {
         return PostImageResponse.builder()
-                .id(image.getId())
-                .alt(image.getAlt())
-                .src(image.getSrc())
-                .build();
+            .id(image.getId())
+            .alt(image.getAlt())
+            .src(image.getSrc())
+            .build();
     }
 }

--- a/src/main/java/site/festifriends/domain/post/dto/PostReactionRequest.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostReactionRequest.java
@@ -1,0 +1,17 @@
+package site.festifriends.domain.post.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostReactionRequest {
+
+    @NotNull(message = "반응 여부는 필수입니다.")
+    private Boolean hasReactioned;
+
+    public PostReactionRequest(Boolean hasReactioned) {
+        this.hasReactioned = hasReactioned;
+    }
+}

--- a/src/main/java/site/festifriends/domain/post/dto/PostResponse.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostResponse.java
@@ -1,13 +1,12 @@
 package site.festifriends.domain.post.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
-import lombok.Getter;
-import site.festifriends.entity.Post;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.entity.Post;
 
 @Getter
 @Builder
@@ -26,7 +25,7 @@ public class PostResponse {
     @JsonProperty("isMine")
     private boolean isMine;
 
-    @JsonProperty("hasReactioned")
+    @JsonProperty("isReactioned")
     private boolean hasReactioned;
 
     private int imageCount;

--- a/src/main/java/site/festifriends/domain/post/dto/PostResponse.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostResponse.java
@@ -26,6 +26,9 @@ public class PostResponse {
     @JsonProperty("isMine")
     private boolean isMine;
 
+    @JsonProperty("hasReactioned")
+    private boolean hasReactioned;
+
     private int imageCount;
     private List<PostImageResponse> images;
     private PostAuthorResponse author;
@@ -35,10 +38,14 @@ public class PostResponse {
     private int reactionCount;
 
     public static PostResponse from(Post post) {
-        return from(post, null);
+        return from(post, null, false);
     }
 
     public static PostResponse from(Post post, Long currentUserId) {
+        return from(post, currentUserId, false);
+    }
+
+    public static PostResponse from(Post post, Long currentUserId, boolean hasReactioned) {
         boolean isMine = currentUserId != null && post.isMine(currentUserId);
 
         return PostResponse.builder()
@@ -48,6 +55,7 @@ public class PostResponse {
             .isPinned(post.isPinned())
             .isReported(post.isReported())
             .isMine(isMine)
+            .hasReactioned(hasReactioned)
             .imageCount(post.getImageCount())
             .images(post.getImages().stream()
                 .map(PostImageResponse::from)

--- a/src/main/java/site/festifriends/domain/post/repository/PostReactionRepository.java
+++ b/src/main/java/site/festifriends/domain/post/repository/PostReactionRepository.java
@@ -1,0 +1,31 @@
+package site.festifriends.domain.post.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import site.festifriends.entity.PostReaction;
+
+public interface PostReactionRepository extends JpaRepository<PostReaction, Long> {
+
+    /**
+     * 특정 게시글에 대한 특정 회원의 반응 존재 여부 확인
+     */
+    @Query("SELECT pr FROM PostReaction pr WHERE pr.post.id = :postId AND pr.member.id = :memberId")
+    Optional<PostReaction> findByPostIdAndMemberId(@Param("postId") Long postId, @Param("memberId") Long memberId);
+
+    /**
+     * 특정 게시글에 대한 특정 회원의 반응 존재 여부 확인 (boolean 반환)
+     */
+    boolean existsByPostIdAndMemberId(Long postId, Long memberId);
+
+    /**
+     * 특정 게시글에 대한 전체 반응 수 조회
+     */
+    long countByPostId(Long postId);
+
+    /**
+     * 특정 게시글에 대한 특정 회원의 반응 삭제
+     */
+    void deleteByPostIdAndMemberId(Long postId, Long memberId);
+}

--- a/src/main/java/site/festifriends/domain/review/dto/RecentReviewResponse.java
+++ b/src/main/java/site/festifriends/domain/review/dto/RecentReviewResponse.java
@@ -1,0 +1,41 @@
+package site.festifriends.domain.review.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.entity.enums.GroupCategory;
+import site.festifriends.entity.enums.ReviewTag;
+
+@Getter
+@Builder
+public class RecentReviewResponse {
+
+    private String groupId;
+    private Performance performance;
+    private String groupTitle;
+    private GroupCategory category;
+    private String groupStartDate;
+    private String groupEndDate;
+    private List<ReviewInfo> reviews;
+
+    @Getter
+    @Builder
+    public static class Performance {
+
+        private String id;
+        private String title;
+        private String poster;
+    }
+
+    @Getter
+    @Builder
+    public static class ReviewInfo {
+
+        private String reviewId;
+        private Double rating;
+        private String content;
+        private List<ReviewTag> defaultTag;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/site/festifriends/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,11 +1,15 @@
 package site.festifriends.domain.review.repository;
 
+import java.util.List;
 import site.festifriends.entity.Member;
 import site.festifriends.entity.Review;
 
-import java.util.List;
-
 public interface ReviewRepositoryCustom {
+
+    /**
+     * 최근 작성된 리뷰 기준으로 모임을 조회 (TOP N)
+     */
+    List<Review> findRecentReviews(int limit);
 
     /**
      * 특정 사용자가 받은 리뷰들을 그룹별로 조회

--- a/src/main/java/site/festifriends/entity/Comments.java
+++ b/src/main/java/site/festifriends/entity/Comments.java
@@ -1,0 +1,76 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.festifriends.common.model.SoftDeleteEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "comment",
+    indexes = {
+        @Index(name = "idx_comment_post_id", columnList = "post_id"),
+        @Index(name = "idx_comment_author_id", columnList = "author_id"),
+        @Index(name = "idx_comment_created_at", columnList = "created_at")
+    })
+public class Comments extends SoftDeleteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private Member author;
+
+    @Column(name = "content", nullable = false, length = 500)
+    private String content;
+
+    @Column(name = "is_reported", nullable = false)
+    private boolean isReported = false;
+
+    @Builder
+    public Comments(Post post, Member author, String content) {
+        this.post = post;
+        this.author = author;
+        this.content = content;
+    }
+
+    /**
+     * 자신의 댓글인지 확인
+     */
+    public boolean isMine(Long memberId) {
+        return author.getId().equals(memberId);
+    }
+
+    /**
+     * 댓글 내용 수정
+     */
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    /**
+     * 댓글 신고 처리
+     */
+    public void report() {
+        this.isReported = true;
+    }
+}

--- a/src/main/java/site/festifriends/entity/Post.java
+++ b/src/main/java/site/festifriends/entity/Post.java
@@ -69,6 +69,9 @@ public class Post extends SoftDeleteEntity {
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
     private List<PostReaction> reactions = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private List<Comments> comments = new ArrayList<>();
+
     @Builder
     public Post(Group group, Member author, String content) {
         this.group = group;

--- a/src/main/java/site/festifriends/entity/Post.java
+++ b/src/main/java/site/festifriends/entity/Post.java
@@ -66,6 +66,9 @@ public class Post extends SoftDeleteEntity {
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
     private List<PostImage> images = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private List<PostReaction> reactions = new ArrayList<>();
+
     @Builder
     public Post(Group group, Member author, String content) {
         this.group = group;

--- a/src/main/java/site/festifriends/entity/PostReaction.java
+++ b/src/main/java/site/festifriends/entity/PostReaction.java
@@ -1,0 +1,55 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import site.festifriends.common.model.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "post_reaction",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_post_reaction_post_member",
+        columnNames = {"post_id", "member_id"}
+    ),
+    indexes = {
+        @Index(name = "idx_post_reaction_post_id", columnList = "post_id"),
+        @Index(name = "idx_post_reaction_member_id", columnList = "member_id")
+    })
+public class PostReaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_reaction_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    @Comment("게시글")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    @Comment("반응한 회원")
+    private Member member;
+
+    @Builder
+    public PostReaction(Post post, Member member) {
+        this.post = post;
+        this.member = member;
+    }
+}


### PR DESCRIPTION
 ## 📋 작업 내용

### ✨ 새로운 기능
- **게시글 반응 등록/취소 API** 추가
- **게시글 상세 조회 API** 추가
- **게시글 목록에 반응 여부 정보** 포함

### 🔧 주요 변경사항

#### 1. 새로운 엔티티 및 Repository
- `PostReaction` 엔티티 생성
  - Post와 Member 간의 다대다 관계 관리
  - 복합 유니크 제약조건으로 중복 반응 방지
- `PostReactionRepository` 구현
  - 반응 존재 여부, 개수 조회 등 기본 기능 제공

#### 2. API 엔드포인트 추가
- `PATCH /api/v1/groups/{groupId}/posts/{postId}/reaction`
  - 게시글 반응 등록/취소
  - 토글 방식으로 동작 (`hasReactioned`: true/false)
- `GET /api/v1/groups/{groupId}/posts/{postId}`
  - 게시글 상세 정보 조회
  - 현재 사용자의 반응 여부 포함

#### 3. 기존 API 개선
- 게시글 목록 조회 시 `isReactioned` 필드 추가
- 현재 사용자가 각 게시글에 반응했는지 여부 표시