### PR TITLE
♻️refactor: 유저가 찜한 사용자 목록 / 사용자 수 / 공연 목록 조회 변경

### DIFF
--- a/src/main/java/site/festifriends/domain/image/dto/ImageDto.java
+++ b/src/main/java/site/festifriends/domain/image/dto/ImageDto.java
@@ -1,4 +1,4 @@
-package site.festifriends.domain.member.dto;
+package site.festifriends.domain.image.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class LikedPerformanceImageDto {
+public class ImageDto {
 
     private String id;
     private String src;

--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.member.dto.LikedMemberCountResponse;
 import site.festifriends.domain.member.dto.LikedMemberResponse;
 import site.festifriends.domain.member.service.MemberService;
 
@@ -44,7 +45,10 @@ public class MemberController implements MemberApi {
     @GetMapping("/favorites/count")
     public ResponseEntity<?> getMyLikedMembersCount(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         Long count = memberService.getMyLikedMembersCount(userDetails.getMemberId());
-        return ResponseEntity.ok(ResponseWrapper.success("요청이 성공적으로 처리되었습니다.", count));
+        return ResponseEntity.ok(ResponseWrapper.success(
+            "요청이 성공적으로 처리되었습니다.",
+            new LikedMemberCountResponse(count)
+        ));
     }
 
     @Override

--- a/src/main/java/site/festifriends/domain/member/dto/LikedMemberCountResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedMemberCountResponse.java
@@ -1,0 +1,12 @@
+package site.festifriends.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikedMemberCountResponse {
+
+    private Long favoriteCount;
+
+}

--- a/src/main/java/site/festifriends/domain/member/dto/LikedMemberDto.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedMemberDto.java
@@ -13,7 +13,7 @@ public class LikedMemberDto {
     private String gender;
     private Integer age;
     private String userUid;
-    private List<ImageDto> profileImage;
+    private ImageDto profileImage;
     private List<String> hashtag;
     private Long bookmarkId;
 

--- a/src/main/java/site/festifriends/domain/member/dto/LikedMemberDto.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedMemberDto.java
@@ -3,6 +3,7 @@ package site.festifriends.domain.member.dto;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import site.festifriends.domain.image.dto.ImageDto;
 
 @Getter
 @AllArgsConstructor
@@ -12,8 +13,7 @@ public class LikedMemberDto {
     private String gender;
     private Integer age;
     private String userUid;
-    private Boolean isUserNew;
-    private String profileImage;
+    private List<ImageDto> profileImage;
     private List<String> hashtag;
     private Long bookmarkId;
 

--- a/src/main/java/site/festifriends/domain/member/dto/LikedMemberResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedMemberResponse.java
@@ -3,6 +3,7 @@ package site.festifriends.domain.member.dto;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import site.festifriends.domain.image.dto.ImageDto;
 
 @Getter
 @AllArgsConstructor
@@ -12,7 +13,7 @@ public class LikedMemberResponse {
     private String gender;
     private Integer age;
     private String userUid;
-    private Boolean isUserNew;
-    private String profileImage;
+    private List<ImageDto> profileImage;
     private List<String> hashtag;
+    private Boolean isLiked;
 }

--- a/src/main/java/site/festifriends/domain/member/dto/LikedMemberResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedMemberResponse.java
@@ -13,7 +13,7 @@ public class LikedMemberResponse {
     private String gender;
     private Integer age;
     private String userUid;
-    private List<ImageDto> profileImage;
+    private ImageDto profileImage;
     private List<String> hashtag;
     private Boolean isLiked;
 }

--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceDto.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import site.festifriends.domain.image.dto.ImageDto;
 
 @Getter
 @AllArgsConstructor
@@ -26,7 +27,7 @@ public class LikedPerformanceDto {
     private String poster;
     private String state;
     private String visit;
-    private List<LikedPerformanceImageDto> images;
+    private List<ImageDto> images;
     private List<String> time;
     private Long bookmarkId;
 }

--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import site.festifriends.domain.image.dto.ImageDto;
 
 @Getter
 @AllArgsConstructor
@@ -26,7 +27,7 @@ public class LikedPerformanceResponse {
     private String poster;
     private String state;
     private String visit;
-    private List<LikedPerformanceImageDto> images;
+    private List<ImageDto> images;
     private List<String> time;
     private Integer groupCount;
 }

--- a/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/LikedPerformanceResponse.java
@@ -30,4 +30,6 @@ public class LikedPerformanceResponse {
     private List<ImageDto> images;
     private List<String> time;
     private Integer groupCount;
+    private Integer favoriteCount;
+    private Boolean isLiked;
 }

--- a/src/main/java/site/festifriends/domain/member/repository/BookmarkRepository.java
+++ b/src/main/java/site/festifriends/domain/member/repository/BookmarkRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import site.festifriends.entity.Bookmark;
 import site.festifriends.entity.enums.BookmarkType;
 
-public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, BookmarkRepositoryCustom {
 
     Optional<Bookmark> findByMemberIdAndTypeAndTargetId(Long memberId, BookmarkType type, Long targetId);
 

--- a/src/main/java/site/festifriends/domain/member/repository/BookmarkRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/member/repository/BookmarkRepositoryCustom.java
@@ -1,0 +1,9 @@
+package site.festifriends.domain.member.repository;
+
+import java.util.List;
+import java.util.Map;
+
+public interface BookmarkRepositoryCustom {
+
+    Map<Long, Integer> getCountByPerformanceIds(List<Long> performanceIds);
+}

--- a/src/main/java/site/festifriends/domain/member/repository/BookmarkRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/member/repository/BookmarkRepositoryImpl.java
@@ -1,0 +1,46 @@
+package site.festifriends.domain.member.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BookmarkRepositoryImpl implements BookmarkRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Map<Long, Integer> getCountByPerformanceIds(List<Long> performanceIds) {
+        String sql = """
+            SELECT b.target_id, COUNT(*)
+            FROM bookmark b
+            WHERE b.target_id IN :performanceIds
+            AND b.type = 'PERFORMANCE'
+            GROUP BY b.target_id
+            """;
+
+        Query query = em.createNativeQuery(sql);
+
+        query.setParameter("performanceIds", performanceIds);
+
+        List<Object[]> result = query.getResultList();
+
+        Map<Long, Integer> countMap = new HashMap<>();
+        for (Long id : performanceIds) {
+            countMap.put(id, 0);
+        }
+
+        for (Object[] row : result) {
+            Long targetId = ((Number) row[0]).longValue();
+            Integer count = ((Number) row[1]).intValue();
+            countMap.put(targetId, count);
+        }
+
+        return countMap;
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/repository/MemberImageRepository.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberImageRepository.java
@@ -1,0 +1,8 @@
+package site.festifriends.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.MemberImage;
+
+public interface MemberImageRepository extends JpaRepository<MemberImage, Long> {
+
+}

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
@@ -58,7 +58,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 (String) row[1],
                 (Integer) row[2],
                 row[3].toString(),
-                parseImages((String) row[4]),
+                parseImage((String) row[4]),
                 row[5] == null ? new ArrayList<>() :
                     Arrays.stream(((String) row[5]).split(","))
                         .map(tag -> "#" + tag)
@@ -181,6 +181,21 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
             return new ArrayList<>();
         }
         return Arrays.asList(value.split(delimiter));
+    }
+
+    private ImageDto parseImage(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        String[] parts = value.split("\\|");
+        String id = parts.length > 0 ? parts[0] : null;
+        String src = parts.length > 1 ? parts[1] : null;
+        String alt = parts.length > 2 ? parts[2] : null;
+        return ImageDto.builder()
+            .id(id)
+            .src(src)
+            .alt(alt)
+            .build();
     }
 
     private List<ImageDto> parseImages(String value) {

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
@@ -29,13 +29,16 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         int pageSize = pageable.getPageSize() + 1;
 
         String sql = """
-            SELECT m.nickname, m.gender, m.age, m.member_id, m.profile_image_url, GROUP_CONCAT(mt.tag) as tags, b.bookmark_id
+            SELECT m.nickname, m.gender, m.age, m.member_id,
+            GROUP_CONCAT(DISTINCT CONCAT(mi.member_id, '|', mi.src, '|', IFNULL(mi.alt, ''))) AS images,
+            GROUP_CONCAT(mt.tag) as tags, b.bookmark_id
             FROM bookmark b
             JOIN member m ON b.target_id = m.member_id
             LEFT JOIN member_tags mt ON m.member_id = mt.member_id
+            LEFT JOIN member_image mi ON m.member_id = mi.member_id
             WHERE b.member_id = :memberId
             AND b.type = 'MEMBER'
-            AND (:cursorId IS NULL OR b.bookmark_id < :cursorId)
+            AND (:cursorId IS NULL OR b.bookmark_id <= :cursorId)
             GROUP BY m.nickname, m.gender, m.age, m.member_id, m.profile_image_url, b.bookmark_id
             ORDER BY b.bookmark_id DESC
             LIMIT :pageSize
@@ -55,8 +58,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 (String) row[1],
                 (Integer) row[2],
                 row[3].toString(),
-                false,
-                (String) row[4],
+                parseImages((String) row[4]),
                 row[5] == null ? new ArrayList<>() :
                     Arrays.stream(((String) row[5]).split(","))
                         .map(tag -> "#" + tag)
@@ -121,7 +123,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
             LEFT JOIN performance_time pt ON p.performance_id = pt.performance_id
             WHERE b.member_id = :memberId
             AND b.type = 'PERFORMANCE'
-            AND (:cursorId IS NULL OR b.bookmark_id < :cursorId)
+            AND (:cursorId IS NULL OR b.bookmark_id <= :cursorId)
             GROUP BY p.performance_id, p.title, p.start_date, p.end_date, p.location,
             p.runtime, p.age, p.poster_url, p.state, p.visit, b.bookmark_id
             ORDER BY b.bookmark_id DESC

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryImpl.java
@@ -13,9 +13,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
+import site.festifriends.domain.image.dto.ImageDto;
 import site.festifriends.domain.member.dto.LikedMemberDto;
 import site.festifriends.domain.member.dto.LikedPerformanceDto;
-import site.festifriends.domain.member.dto.LikedPerformanceImageDto;
 
 @Repository
 @RequiredArgsConstructor
@@ -156,7 +156,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 String state = String.valueOf(row[15]);
                 String visit = (String) row[16];
 
-                List<LikedPerformanceImageDto> images = parseImages((String) row[17]);
+                List<ImageDto> images = parseImages((String) row[17]);
                 List<String> time = splitToList((String) row[18], "\\|");
 
                 Long bookmarkId = row[19] == null ? null : ((Number) row[19]).longValue();
@@ -181,7 +181,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         return Arrays.asList(value.split(delimiter));
     }
 
-    private List<LikedPerformanceImageDto> parseImages(String value) {
+    private List<ImageDto> parseImages(String value) {
         if (value == null || value.isEmpty()) {
             return new ArrayList<>();
         }
@@ -191,7 +191,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 String id = parts.length > 0 ? parts[0] : null;
                 String src = parts.length > 1 ? parts[1] : null;
                 String alt = parts.length > 2 ? parts[2] : null;
-                return LikedPerformanceImageDto.builder()
+                return ImageDto.builder()
                     .id(id)
                     .src(src)
                     .alt(alt)

--- a/src/main/java/site/festifriends/domain/post/dto/PostAuthorResponse.java
+++ b/src/main/java/site/festifriends/domain/post/dto/PostAuthorResponse.java
@@ -12,6 +12,7 @@ public class PostAuthorResponse {
     private String name;
     private String profileImage;
 
+    // profile image 어떻게 처리할건지?
     public static PostAuthorResponse from(Member member) {
         return PostAuthorResponse.builder()
             .id(member.getId())

--- a/src/main/java/site/festifriends/entity/Member.java
+++ b/src/main/java/site/festifriends/entity/Member.java
@@ -42,7 +42,7 @@ public class Member extends SoftDeleteEntity {
     @Column(name = "nickname", length = 20, nullable = false)
     @Comment("닉네임")
     private String nickname;
-    
+
     @Column(name = "age", nullable = false)
     @Comment("나이")
     private Integer age;
@@ -55,6 +55,10 @@ public class Member extends SoftDeleteEntity {
     @Column(name = "introduce", length = 150)
     @Comment("유저 자기소개")
     private String introduction;
+
+    @Column(name = "profile_image_url", length = 255)
+    @Comment("프로필 이미지 URL")
+    private String profileImageUrl;
 
     @Builder.Default
     @ElementCollection

--- a/src/main/java/site/festifriends/entity/Member.java
+++ b/src/main/java/site/festifriends/entity/Member.java
@@ -42,11 +42,7 @@ public class Member extends SoftDeleteEntity {
     @Column(name = "nickname", length = 20, nullable = false)
     @Comment("닉네임")
     private String nickname;
-
-    @Column(name = "profile_image_url", nullable = false)
-    @Comment("프로필 이미지 URL")
-    private String profileImageUrl;
-
+    
     @Column(name = "age", nullable = false)
     @Comment("나이")
     private Integer age;

--- a/src/main/java/site/festifriends/entity/MemberImage.java
+++ b/src/main/java/site/festifriends/entity/MemberImage.java
@@ -1,0 +1,49 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import site.festifriends.common.model.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member_image")
+public class MemberImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_image_id", nullable = false)
+    private Long id;
+
+    @Column(name = "src", nullable = false)
+    @Comment("소개 이미지 URL")
+    private String src;
+
+    @Column(name = "alt")
+    @Comment("소개 이미지 설명")
+    private String alt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder
+    public MemberImage(Member member, String src, String alt) {
+        this.member = member;
+        this.src = src;
+        this.alt = alt;
+    }
+
+}

--- a/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,8 +22,8 @@ import site.festifriends.domain.performance.repository.PerformanceImageRepositor
 import site.festifriends.domain.performance.repository.PerformanceRepository;
 import site.festifriends.entity.Bookmark;
 import site.festifriends.entity.Member;
+import site.festifriends.entity.MemberImage;
 import site.festifriends.entity.Performance;
-import site.festifriends.entity.PerformanceImage;
 import site.festifriends.entity.enums.BookmarkType;
 import site.festifriends.entity.enums.Gender;
 import site.festifriends.entity.enums.PerformanceState;
@@ -33,7 +34,7 @@ import site.festifriends.entity.enums.PerformanceState;
 public class MemberRepositoryTest {
 
     @Autowired
-    private MemberRepositoryImpl memberRepositoryImpl; // 혹은 MemberRepositoryCustom
+    private MemberRepositoryImpl memberRepositoryImpl;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -47,41 +48,116 @@ public class MemberRepositoryTest {
     @Autowired
     private PerformanceImageRepository performanceImageRepository;
 
-    @Test
-    @DisplayName("[성공] 내가 찜한 사용자 목록 조회")
-    void getMyLikedMembers_test() {
-        // given
-        Member member = memberRepository.save(Member.builder()
+    private Member member;
+    private Member target1;
+    private Member target2;
+    private MemberImage memberImage;
+    private MemberImage targetImage1;
+    private MemberImage targetImage2;
+    private Performance targetPerformance1;
+    private Performance targetPerformance2;
+    @Autowired
+    private MemberImageRepository memberImageRepository;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(Member.builder()
             .email("test1@example.com")
-            .nickname("테스트")
-            .profileImageUrl("https://example.com/profiles/test1.jpg")
+            .nickname("테스트1")
             .age(28)
             .gender(Gender.MALE)
-            .introduction("안녕하세요.")
+            .introduction("테스트 1번 멤버")
             .tags(List.of("음악", "여행"))
+            .sns(List.of("github", "instagram"))
             .socialId("socialId1")
             .build());
 
-        Member target1 = memberRepository.save(Member.builder()
+        target1 = memberRepository.save(Member.builder()
             .email("test2@example.com")
             .nickname("테스트2")
-            .profileImageUrl("https://example.com/profiles/test2.jpg")
-            .age(20)
+            .age(30)
             .gender(Gender.MALE)
-            .introduction("안녕하세요.")
-            .tags(List.of("음악", "여행"))
+            .introduction("테스트 2번 멤버")
+            .tags(List.of("피아노", "기타"))
+            .sns(List.of("github", "instagram"))
             .socialId("socialId2")
             .build());
 
-        Member target2 = memberRepository.save(Member.builder()
+        target2 = memberRepository.save(Member.builder()
             .email("test3@example.com")
             .nickname("테스트3")
-            .profileImageUrl("https://example.com/profiles/test3.jpg")
-            .age(21)
-            .gender(Gender.MALE)
-            .introduction("안녕하세요.")
-            .tags(List.of("음악", "여행"))
+            .age(31)
+            .gender(Gender.FEMALE)
+            .introduction("테스트 3번 멤버")
+            .tags(List.of("게임", "공부"))
+            .sns(List.of("github", "instagram"))
             .socialId("socialId3")
+            .build());
+
+        memberImage = memberImageRepository.save(MemberImage.builder()
+            .member(member)
+            .src("https://example.com/profiles/test1.jpg")
+            .alt("테스트1 프로필 이미지")
+            .build());
+
+        targetImage1 = memberImageRepository.save(MemberImage.builder()
+            .member(target1)
+            .src("https://example.com/profiles/test2.jpg")
+            .alt("테스트2 프로필 이미지")
+            .build());
+
+        targetImage2 = memberImageRepository.save(MemberImage.builder()
+            .member(target2)
+            .src("https://example.com/profiles/test3.jpg")
+            .alt("테스트3 프로필 이미지")
+            .build());
+
+        targetPerformance1 = performanceRepository.save(Performance.builder()
+            .title("테스트 공연 1")
+            .startDate(LocalDateTime.of(2025, 5, 30, 18, 0))
+            .endDate(LocalDateTime.of(2025, 6, 1, 22, 0))
+            .location("올림픽공원")
+            .cast(List.of("배우1", "배우2"))
+            .crew(List.of("감독1", "작가1"))
+            .runtime("180분")
+            .age("만 12세 이상")
+            .productionCompany(List.of("제작사1"))
+            .agency(List.of("기획사1"))
+            .host(List.of("주최1"))
+            .organizer(List.of("주관사1"))
+            .price(List.of("VIP 10만원", "R석 8만원", "S석 5만원"))
+            .poster("https://example.com/poster1.jpg")
+            .state(PerformanceState.UPCOMING)
+            .visit("국내")
+            .time(List.of(
+                "화요일 ~ 금요일(20:00)",
+                "토요일(16:00,19:00)",
+                "일요일(15:00,18:00)"
+            ))
+            .build());
+
+        targetPerformance2 = performanceRepository.save(Performance.builder()
+            .title("테스트 공연 2")
+            .startDate(LocalDateTime.of(2025, 6, 5, 18, 0))
+            .endDate(LocalDateTime.of(2025, 6, 7, 22, 0))
+            .location("세종문화회관")
+            .cast(List.of("배우3", "배우4"))
+            .crew(List.of("감독2", "작가2"))
+            .runtime("150분")
+            .age("만 15세 이상")
+            .productionCompany(List.of("제작사2"))
+            .agency(List.of("기획사2"))
+            .host(List.of("주최2"))
+            .organizer(List.of("주관사2"))
+            .price(List.of("VIP 12만원", "R석 10만원", "S석 7만원"))
+            .poster("https://example.com/poster2.jpg")
+            .state(PerformanceState.UPCOMING)
+            .visit("국내")
+            .time(List.of(
+                "화요일 ~ 금요일(19:00)",
+                "토요일(15:00,18:00)",
+                "일요일(14:00,17:00)"
+            ))
             .build());
 
         bookmarkRepository.save(
@@ -100,6 +176,27 @@ public class MemberRepositoryTest {
                 .build()
         );
 
+        bookmarkRepository.save(
+            Bookmark.builder()
+                .member(member)
+                .type(BookmarkType.PERFORMANCE)
+                .targetId(targetPerformance1.getId())
+                .build()
+        );
+
+        bookmarkRepository.save(
+            Bookmark.builder()
+                .member(member)
+                .type(BookmarkType.PERFORMANCE)
+                .targetId(targetPerformance2.getId())
+                .build()
+        );
+    }
+
+    @Test
+    @DisplayName("[성공] 내가 찜한 사용자 목록 조회")
+    void getMyLikedMembers_test() {
+        // given
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
@@ -113,70 +210,20 @@ public class MemberRepositoryTest {
 
         LikedMemberDto dto1 = content.get(0);
         assertThat(dto1.getName()).isEqualTo("테스트3");
-        assertThat(dto1.getGender()).isEqualTo("MALE");
-        assertThat(dto1.getAge()).isEqualTo(21);
-        assertThat(dto1.getProfileImage()).isEqualTo("https://example.com/profiles/test3.jpg");
+        assertThat(dto1.getGender()).isEqualTo("FEMALE");
+        assertThat(dto1.getAge()).isEqualTo(31);
+        assertThat(dto1.getProfileImage().getSrc()).isEqualTo("https://example.com/profiles/test3.jpg");
 
         LikedMemberDto dto2 = content.get(1);
         assertThat(dto2.getName()).isEqualTo("테스트2");
         assertThat(dto2.getGender()).isEqualTo("MALE");
-        assertThat(dto2.getAge()).isEqualTo(20);
-        assertThat(dto2.getProfileImage()).isEqualTo("https://example.com/profiles/test2.jpg");
+        assertThat(dto2.getAge()).isEqualTo(30);
+        assertThat(dto2.getProfileImage().getSrc()).isEqualTo("https://example.com/profiles/test2.jpg");
     }
 
     @Test
     @DisplayName("[성공] 내가 찜한 사용자 수 조회")
     void getMyLikedMembersCount_test() {
-        // given
-        Member member = memberRepository.save(Member.builder()
-            .email("test1@example.com")
-            .nickname("테스트")
-            .profileImageUrl("https://example.com/profiles/test1.jpg")
-            .age(28)
-            .gender(Gender.MALE)
-            .introduction("안녕하세요.")
-            .tags(List.of("음악", "여행"))
-            .socialId("socialId1")
-            .build());
-
-        Member target1 = memberRepository.save(Member.builder()
-            .email("test2@example.com")
-            .nickname("테스트2")
-            .profileImageUrl("https://example.com/profiles/test2.jpg")
-            .age(20)
-            .gender(Gender.MALE)
-            .introduction("안녕하세요.")
-            .tags(List.of("음악", "여행"))
-            .socialId("socialId2")
-            .build());
-
-        Member target2 = memberRepository.save(Member.builder()
-            .email("test3@example.com")
-            .nickname("테스트3")
-            .profileImageUrl("https://example.com/profiles/test3.jpg")
-            .age(21)
-            .gender(Gender.MALE)
-            .introduction("안녕하세요.")
-            .tags(List.of("음악", "여행"))
-            .socialId("socialId3")
-            .build());
-
-        bookmarkRepository.save(
-            Bookmark.builder()
-                .member(member)
-                .type(BookmarkType.MEMBER)
-                .targetId(target1.getId())
-                .build()
-        );
-
-        bookmarkRepository.save(
-            Bookmark.builder()
-                .member(member)
-                .type(BookmarkType.MEMBER)
-                .targetId(target2.getId())
-                .build()
-        );
-
         // when
         Long count = memberRepositoryImpl.countMyLikedMembers(member.getId());
 
@@ -188,52 +235,6 @@ public class MemberRepositoryTest {
     @DisplayName("[성공] 내가 찜한 공연 목록 조회")
     void getMyLikedPerformances_test() {
         // given
-        Member member = memberRepository.save(Member.builder()
-            .email("test1@example.com")
-            .nickname("테스터")
-            .profileImageUrl("https://example.com/profile.jpg")
-            .age(28)
-            .gender(Gender.MALE)
-            .introduction("소개")
-            .socialId("social1")
-            .build());
-
-        Performance performance = performanceRepository.save(Performance.builder()
-            .title("테스트 공연")
-            .startDate(LocalDateTime.of(2025, 5, 30, 18, 0))
-            .endDate(LocalDateTime.of(2025, 6, 1, 22, 0))
-            .location("올림픽공원")
-            .cast(List.of("배우1", "배우2"))
-            .crew(List.of("감독1", "작가1"))
-            .runtime("180분")
-            .age("만 12세 이상")
-            .productionCompany(List.of("제작사1"))
-            .agency(List.of("기획사1"))
-            .host(List.of("주최1"))
-            .organizer(List.of("주관사1"))
-            .price(List.of("VIP 10만원", "R석 8만원", "S석 5만원"))
-            .poster("https://example.com/poster.jpg")
-            .state(PerformanceState.UPCOMING)
-            .visit("국내")
-            .time(List.of(
-                "화요일 ~ 금요일(20:00)",
-                "토요일(16:00,19:00)",
-                "일요일(15:00,18:00)"
-            ))
-            .build());
-
-        PerformanceImage pr1 = new PerformanceImage(performance, "https://example.com/img1.jpg", "이미지1");
-        PerformanceImage pr2 = new PerformanceImage(performance, "https://example.com/img2.jpg", "이미지2");
-        performanceImageRepository.save(pr1);
-        performanceImageRepository.save(pr2);
-
-        bookmarkRepository.save(
-            Bookmark.builder()
-                .member(member)
-                .type(BookmarkType.PERFORMANCE)
-                .targetId(performance.getId())
-                .build()
-        );
 
         Pageable pageable = PageRequest.of(0, 10);
 
@@ -245,33 +246,15 @@ public class MemberRepositoryTest {
         assertThat(result.hasNext()).isFalse();
         List<LikedPerformanceDto> content = result.getContent();
         assertThat(content).isNotEmpty();
-        LikedPerformanceDto dto = content.get(0);
-        assertThat(dto.getId()).isEqualTo(performance.getId());
-        assertThat(dto.getTitle()).isEqualTo("테스트 공연");
-        assertThat(dto.getStartDate()).isEqualTo(LocalDateTime.of(2025, 5, 30, 18, 0));
-        assertThat(dto.getEndDate()).isEqualTo(LocalDateTime.of(2025, 6, 1, 22, 0));
-        assertThat(dto.getLocation()).isEqualTo("올림픽공원");
-        assertThat(dto.getCast()).containsExactly("배우1", "배우2");
-        assertThat(dto.getCrew()).containsExactly("감독1", "작가1");
-        assertThat(dto.getRuntime()).isEqualTo("180분");
-        assertThat(dto.getAge()).isEqualTo("만 12세 이상");
-        assertThat(dto.getProductionCompany()).containsExactly("제작사1");
-        assertThat(dto.getAgency()).containsExactly("기획사1");
-        assertThat(dto.getHost()).containsExactly("주최1");
-        assertThat(dto.getOrganizer()).containsExactly("주관사1");
-        assertThat(dto.getPrice()).containsExactly("VIP 10만원", "R석 8만원", "S석 5만원");
-        assertThat(dto.getPoster()).isEqualTo("https://example.com/poster.jpg");
-        assertThat(dto.getState()).isEqualTo("UPCOMING");
-        assertThat(dto.getVisit()).isEqualTo("국내");
-        assertThat(dto.getImages()).hasSize(2);
-        assertThat(dto.getImages().get(0).getSrc()).isEqualTo("https://example.com/img1.jpg");
-        assertThat(dto.getImages().get(1).getSrc()).isEqualTo("https://example.com/img2.jpg");
-        assertThat(dto.getTime()).containsExactly(
-            "화요일 ~ 금요일(20:00)",
-            "토요일(16:00,19:00)",
-            "일요일(15:00,18:00)"
-        );
-        assertThat(dto.getBookmarkId()).isNotNull();
-
+        LikedPerformanceDto dto1 = content.get(0);
+        assertThat(dto1.getTitle()).isEqualTo("테스트 공연 2");
+        assertThat(dto1.getStartDate()).isEqualTo(LocalDateTime.of(2025, 6, 5, 18, 0));
+        assertThat(dto1.getEndDate()).isEqualTo(LocalDateTime.of(2025, 6, 7, 22, 0));
+        assertThat(dto1.getPoster()).isEqualTo("https://example.com/poster2.jpg");
+        LikedPerformanceDto dto2 = content.get(1);
+        assertThat(dto2.getTitle()).isEqualTo("테스트 공연 1");
+        assertThat(dto2.getStartDate()).isEqualTo(LocalDateTime.of(2025, 5, 30, 18, 0));
+        assertThat(dto2.getEndDate()).isEqualTo(LocalDateTime.of(2025, 6, 1, 22, 0));
+        assertThat(dto2.getPoster()).isEqualTo("https://example.com/poster1.jpg");
     }
 }

--- a/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
@@ -18,10 +18,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.image.dto.ImageDto;
 import site.festifriends.domain.member.dto.LikedMemberDto;
 import site.festifriends.domain.member.dto.LikedMemberResponse;
 import site.festifriends.domain.member.dto.LikedPerformanceDto;
-import site.festifriends.domain.member.dto.LikedPerformanceImageDto;
 import site.festifriends.domain.member.dto.LikedPerformanceResponse;
 import site.festifriends.domain.member.repository.MemberRepository;
 import site.festifriends.domain.performance.repository.PerformanceRepository;
@@ -123,7 +123,7 @@ class MemberServiceTest {
             "https://example.com/performance1.jpg",
             "UPCOMING",
             "국내",
-            List.of(new LikedPerformanceImageDto("1", "https://example.com/img1.jpg", "이미지1")),
+            List.of(new ImageDto("1", "https://example.com/img1.jpg", "이미지1")),
             List.of("화요일 ~ 금요일(20:00)"),
             100L // bookmarkId
         );
@@ -146,7 +146,7 @@ class MemberServiceTest {
             "https://example.com/performance2.jpg",
             "UPCOMING",
             "국내",
-            List.of(new LikedPerformanceImageDto("2", "https://example.com/img2.jpg", "이미지2")),
+            List.of(new ImageDto("2", "https://example.com/img2.jpg", "이미지2")),
             List.of("토요일(16:00,19:00)"),
             101L // bookmarkId
         );

--- a/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/site/festifriends/domain/member/service/MemberServiceTest.java
@@ -23,6 +23,7 @@ import site.festifriends.domain.member.dto.LikedMemberDto;
 import site.festifriends.domain.member.dto.LikedMemberResponse;
 import site.festifriends.domain.member.dto.LikedPerformanceDto;
 import site.festifriends.domain.member.dto.LikedPerformanceResponse;
+import site.festifriends.domain.member.repository.BookmarkRepository;
 import site.festifriends.domain.member.repository.MemberRepository;
 import site.festifriends.domain.performance.repository.PerformanceRepository;
 
@@ -35,8 +36,12 @@ class MemberServiceTest {
     @Mock
     private PerformanceRepository performanceRepository;
 
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+
     @InjectMocks
     private MemberService memberService;
+
 
     @Test
     @DisplayName("[성공] 내가 찜한 유저 목록 조회(nextCursor 존재)")
@@ -47,11 +52,13 @@ class MemberServiceTest {
         int size = 2;
 
         LikedMemberDto member1 = new LikedMemberDto(
-            "테스트1", "Male", 28, "1L", false, "https://example.com/1.jpg", List.of("#음악", "#여행"), 100L);
+            "테스트1", "Male", 28, "1L", new ImageDto("1", "https://example.com/1.jpg", "이미지1"), List.of("#음악", "#여행"),
+            100L);
         LikedMemberDto member2 = new LikedMemberDto(
-            "테스트2", "Female", 25, "2L", false, "https://example.com/2.jpg", List.of("#운동", "#독서"), 99L);
+            "테스트2", "Female", 25, "2L", new ImageDto("2", "https://example.com/2.jpg", "이미지2"), List.of("#운동", "#독서"),
+            99L);
         LikedMemberDto member3 = new LikedMemberDto(
-            "테스트3", "Male", 30, "3L", false, "https://example.com/3.jpg", List.of("#사진"), 98L);
+            "테스트3", "Male", 30, "3L", new ImageDto("3", "https://example.com/3.jpg", "이미지3"), List.of("#사진"), 98L);
 
         List<LikedMemberDto> memberList = Arrays.asList(member1, member2, member3);
         Slice<LikedMemberDto> slice = new SliceImpl<>(memberList, PageRequest.of(0, size + 1), true);
@@ -78,9 +85,11 @@ class MemberServiceTest {
         int size = 2;
 
         LikedMemberDto member1 = new LikedMemberDto(
-            "테스트1", "Male", 28, "1L", false, "https://example.com/1.jpg", List.of("#음악", "#여행"), 100L);
+            "테스트1", "Male", 28, "1L", new ImageDto("1", "https://example.com/1.jpg", "이미지1"), List.of("#음악", "#여행"),
+            100L);
         LikedMemberDto member2 = new LikedMemberDto(
-            "테스트2", "Female", 25, "2L", false, "https://example.com/2.jpg", List.of("#운동", "#독서"), 99L);
+            "테스트2", "Female", 25, "2L", new ImageDto("2", "https://example.com/2.jpg", "이미지2"), List.of("#운동", "#독서"),
+            99L);
 
         List<LikedMemberDto> memberList = Arrays.asList(member1, member2);
         Slice<LikedMemberDto> slice = new SliceImpl<>(memberList, PageRequest.of(0, size + 1), false);


### PR DESCRIPTION
## 작업 내용
- [♻️refactor: 이미지 관련 dto 구조 통일로 인해 객체 통일](https://github.com/FestiFriends/ff_backend/commit/1a39402bc74da43bb43a68370692aa34dd23b37d)
  - 이미지 응답 구조가 "id, src, alt" 로 정형화 되어 있어 별도의 객체로 분리하였습니다.
- [✨feat: 멤버 이미지 분리를 위한 테이블 추가](https://github.com/FestiFriends/ff_backend/commit/045a8c6578cdf26be5de5f0639bd0baacee218b7)
  - 멤버 이미지를 별도로 관리하기 위한 테이블을 생성했습니다.
- [♻️refactor: 내가 찜한 사용자 목록, 사용자 수 공연 api 스펙 변경에 따른 기능 수정](https://github.com/FestiFriends/ff_backend/commit/7ce80755048958ff5847bb79868e5e555d165335)
- [♻️refactor: api 스펙 변경에 따른 테스트 코드 내용 변경](https://github.com/FestiFriends/ff_backend/commit/4f3008decaee7003a2e441be2ec47782ecd0599c)

## 리뷰 포인트
아직 api 문서에 image를 반환하는 부분이 통일되어 있지 않아, Member 테이블 내의 profile_image_url을 다시 추가하였습니다.
추후 스펙 통일화 되었을 시 다시 제거할 예정입니다.