### PR TITLE
✨feat: 프로필 관련 기능 추가(프로필  조회 / 프로필 수정)

### DIFF
--- a/src/main/java/site/festifriends/common/config/SecurityConfig.java
+++ b/src/main/java/site/festifriends/common/config/SecurityConfig.java
@@ -56,9 +56,10 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorizeHttpRequests ->
                 authorizeHttpRequests
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                    .requestMatchers(HttpMethod.GET, readOnlyUrl).permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/groups/{groupId}").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/token").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/profiles/me").authenticated()
+                    .requestMatchers(HttpMethod.GET, readOnlyUrl).permitAll()
                     .anyRequest().authenticated())
             .exceptionHandling(exception ->
                 exception

--- a/src/main/java/site/festifriends/common/config/SecurityConfig.java
+++ b/src/main/java/site/festifriends/common/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
         "/api/v1/performances",
         "/api/v1/performances/**",
         "/api/v1/performances/top-favorites",
-        "/api/v1/performances/top-groups"
+        "/api/v1/performances/top-groups",
+        "/api/v1/profiles/*"
     };
 
     @Bean

--- a/src/main/java/site/festifriends/domain/group/dto/GroupSummaryDto.java
+++ b/src/main/java/site/festifriends/domain/group/dto/GroupSummaryDto.java
@@ -1,0 +1,13 @@
+package site.festifriends.domain.group.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroupSummaryDto {
+
+    private Integer joinedCount;
+    private Integer totalJoinedCount;
+    private Integer createdCount;
+}

--- a/src/main/java/site/festifriends/domain/group/repository/GroupRepository.java
+++ b/src/main/java/site/festifriends/domain/group/repository/GroupRepository.java
@@ -10,7 +10,7 @@ import site.festifriends.entity.Group;
 import site.festifriends.entity.enums.Gender;
 import site.festifriends.entity.enums.GroupCategory;
 
-public interface GroupRepository extends JpaRepository<Group, Long> {
+public interface GroupRepository extends JpaRepository<Group, Long>, GroupRepositoryCustom {
 
     @Query("SELECT g FROM Group g WHERE g.performance.id = :performanceId AND g.deleted IS NULL")
     Page<Group> findByPerformanceId(@Param("performanceId") Long performanceId, Pageable pageable);

--- a/src/main/java/site/festifriends/domain/group/repository/GroupRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/group/repository/GroupRepositoryCustom.java
@@ -1,0 +1,6 @@
+package site.festifriends.domain.group.repository;
+
+public interface GroupRepositoryCustom {
+
+    Object[] getMemberGroupCount(Long targetId);
+}

--- a/src/main/java/site/festifriends/domain/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/group/repository/GroupRepositoryImpl.java
@@ -1,0 +1,38 @@
+package site.festifriends.domain.group.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupRepositoryImpl implements GroupRepositoryCustom {
+
+    private final EntityManager em;
+
+    @Override
+    public Object[] getMemberGroupCount(Long targetId) {
+        String sql = """
+            SELECT
+                (SELECT COUNT(DISTINCT mg1.group_id)
+                                FROM member_group mg1
+                                WHERE mg1.member_id = :targetId
+                                  AND mg1.status IN ('ACCEPTED', 'CONFIRMED')
+                                  AND mg1.deleted IS NULL) AS joinedCount,
+                (SELECT COUNT(DISTINCT mg2.group_id)
+                                FROM member_group mg2
+                                WHERE mg2.member_id = :targetId
+                                  AND mg2.status IN ('ACCEPTED', 'CONFIRMED')) AS joinedCount,
+                (SELECT COUNT(*)
+                                FROM member_group mg3
+                                WHERE mg3.member_id = :targetId
+                                  AND mg3.role = 'HOST'
+                                  AND mg3.status IN ('ACCEPTED', 'CONFIRMED')
+                                  AND mg3.deleted IS NULL) AS createdCount
+            """;
+
+        return (Object[]) em.createNativeQuery(sql)
+            .setParameter("targetId", targetId)
+            .getSingleResult();
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/controller/ProfileApi.java
+++ b/src/main/java/site/festifriends/domain/member/controller/ProfileApi.java
@@ -3,9 +3,14 @@ package site.festifriends.domain.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import site.festifriends.common.response.ResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.member.dto.GetMyProfileResponse;
 import site.festifriends.domain.member.dto.GetProfileResponse;
+import site.festifriends.domain.member.dto.UpdateProfileRequest;
 
 public interface ProfileApi {
 
@@ -14,10 +19,38 @@ public interface ProfileApi {
         description = "유저 프로필 홈 조회 데이터를 반환합니다.",
         responses = {
             @ApiResponse(responseCode = "200", description = "프로필 홈 조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "400", description = "해당하는 회원이 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류입니다."),
         }
     )
     ResponseEntity<ResponseWrapper<GetProfileResponse>> getProfile(
         @PathVariable Long userId
+    );
+
+    @Operation(
+        summary = "마이페이지 - 프로필 카드",
+        description = "회원 본인 프로필 데이터를 반환합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "프로필 홈 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 오류입니다."),
+        }
+    )
+    ResponseEntity<ResponseWrapper<GetMyProfileResponse>> getMyProfile(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    );
+
+    @Operation(
+        summary = "내 프로필 수정",
+        description = "회원 본인의 프로필 데이터를 수정합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 수정되었습니다."),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 회원입니다."),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<ResponseWrapper<?>> updateMyProfile(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestBody UpdateProfileRequest request
     );
 }

--- a/src/main/java/site/festifriends/domain/member/controller/ProfileApi.java
+++ b/src/main/java/site/festifriends/domain/member/controller/ProfileApi.java
@@ -1,0 +1,23 @@
+package site.festifriends.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import site.festifriends.common.response.ResponseWrapper;
+import site.festifriends.domain.member.dto.GetProfileResponse;
+
+public interface ProfileApi {
+
+    @Operation(
+        summary = "프로필 홈",
+        description = "유저 프로필 홈 조회 데이터를 반환합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "프로필 홈 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<ResponseWrapper<GetProfileResponse>> getProfile(
+        @PathVariable Long userId
+    );
+}

--- a/src/main/java/site/festifriends/domain/member/controller/ProfileController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/ProfileController.java
@@ -3,14 +3,19 @@ package site.festifriends.domain.member.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.member.dto.GetMyProfileResponse;
 import site.festifriends.domain.member.dto.GetProfileResponse;
+import site.festifriends.domain.member.dto.UpdateProfileRequest;
 import site.festifriends.domain.member.service.ProfileService;
 
 @RestController
@@ -35,6 +40,30 @@ public class ProfileController implements ProfileApi {
         return ResponseEntity.ok(ResponseWrapper.success(
             "프로필 조회가 성공적으로 처리되었습니다.",
             profileService.getMemberProfile(userId, memberId)
+        ));
+    }
+
+    @Override
+    public ResponseEntity<ResponseWrapper<GetMyProfileResponse>> getMyProfile(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        Long memberId = userDetails.getMemberId();
+        return ResponseEntity.ok(ResponseWrapper.success(
+            "프로필 조회가 성공적으로 처리되었습니다.",
+            profileService.getMyProfile(memberId)
+        ));
+    }
+
+    @Override
+    @PatchMapping("/me")
+    public ResponseEntity<ResponseWrapper<?>> updateMyProfile(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestBody UpdateProfileRequest request
+    ) {
+        profileService.updateMyProfile(userDetails.getMemberId(), request);
+
+        return ResponseEntity.ok(ResponseWrapper.success(
+            "프로필이 성공적으로 수정되었습니다."
         ));
     }
 }

--- a/src/main/java/site/festifriends/domain/member/controller/ProfileController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/ProfileController.java
@@ -1,0 +1,40 @@
+package site.festifriends.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.ResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.member.dto.GetProfileResponse;
+import site.festifriends.domain.member.service.ProfileService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/profiles")
+public class ProfileController implements ProfileApi {
+
+    private final ProfileService profileService;
+
+    @Override
+    @GetMapping("/{userId}")
+    public ResponseEntity<ResponseWrapper<GetProfileResponse>> getProfile(
+        @PathVariable Long userId
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Long memberId = null;
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetailsImpl userDetails) {
+            memberId = userDetails.getMemberId();
+        }
+
+        return ResponseEntity.ok(ResponseWrapper.success(
+            "프로필 조회가 성공적으로 처리되었습니다.",
+            profileService.getMemberProfile(userId, memberId)
+        ));
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/controller/ProfileController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/ProfileController.java
@@ -44,6 +44,7 @@ public class ProfileController implements ProfileApi {
     }
 
     @Override
+    @GetMapping("/me")
     public ResponseEntity<ResponseWrapper<GetMyProfileResponse>> getMyProfile(
         @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {

--- a/src/main/java/site/festifriends/domain/member/dto/GetMyProfileResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/GetMyProfileResponse.java
@@ -1,0 +1,36 @@
+package site.festifriends.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.domain.group.dto.GroupSummaryDto;
+import site.festifriends.domain.image.dto.ImageDto;
+import site.festifriends.domain.review.dto.ReviewSummaryDto;
+
+@Getter
+@Builder
+public class GetMyProfileResponse {
+
+    private String id;
+    private String name;
+    private Integer age;
+    private String gender;
+    private ImageDto profileImage;
+    private String description;
+    private List<String> hashtags;
+    private String sns;
+    private Double rating;
+    @JsonIgnore
+    private Boolean isLiked;
+    @JsonProperty("isReported")
+    private Boolean isReported;
+    @JsonProperty("isMine")
+    private Boolean isMine;
+    private GroupSummaryDto groupSummary;
+    private ReviewSummaryDto reviewSummary;
+    private Integer reviewCount;
+    private List<String> reviewList;
+
+}

--- a/src/main/java/site/festifriends/domain/member/dto/GetProfileResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/GetProfileResponse.java
@@ -1,0 +1,34 @@
+package site.festifriends.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.domain.group.dto.GroupSummaryDto;
+import site.festifriends.domain.image.dto.ImageDto;
+import site.festifriends.domain.review.dto.ReviewSummaryDto;
+
+@Getter
+@Builder
+public class GetProfileResponse {
+
+    private String id;
+    private String name;
+    private Integer age;
+    private String gender;
+    private ImageDto profileImage;
+    private String description;
+    private List<String> hashtags;
+    private String sns;
+    private Double rating;
+    @JsonProperty("isLiked")
+    private Boolean isLiked;
+    @JsonProperty("isReported")
+    private Boolean isReported;
+    @JsonProperty("isMine")
+    private Boolean isMine;
+    private GroupSummaryDto groupSummary;
+    private ReviewSummaryDto reviewSummary;
+    private Integer reviewCount;
+    private List<String> reviewList;
+}

--- a/src/main/java/site/festifriends/domain/member/dto/UpdateProfileRequest.java
+++ b/src/main/java/site/festifriends/domain/member/dto/UpdateProfileRequest.java
@@ -1,0 +1,18 @@
+package site.festifriends.domain.member.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.festifriends.domain.image.dto.ImageDto;
+
+@Getter
+@NoArgsConstructor
+public class UpdateProfileRequest {
+
+    private String name;
+    private Integer age;
+    private ImageDto profileImage;
+    private String description;
+    private List<String> hashtag;
+    private String sns;
+}

--- a/src/main/java/site/festifriends/domain/member/repository/MemberImageRepository.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberImageRepository.java
@@ -1,8 +1,10 @@
 package site.festifriends.domain.member.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.festifriends.entity.MemberImage;
 
 public interface MemberImageRepository extends JpaRepository<MemberImage, Long> {
 
+    Optional<MemberImage> findByMemberId(Long memberId);
 }

--- a/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/member/repository/MemberRepositoryCustom.java
@@ -12,4 +12,8 @@ public interface MemberRepositoryCustom {
     Long countMyLikedMembers(Long memberId);
 
     Slice<LikedPerformanceDto> getMyLikedPerformances(Long memberId, Long cursorId, Pageable pageable);
+
+    Object[] getMemberProfile(Long targetId);
+
+    Object[] getMemberExtraData(Long memberId, Long targetId);
 }

--- a/src/main/java/site/festifriends/domain/member/service/MemberImageService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberImageService.java
@@ -1,0 +1,24 @@
+package site.festifriends.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.festifriends.common.exception.BusinessException;
+import site.festifriends.common.exception.ErrorCode;
+import site.festifriends.domain.image.dto.ImageDto;
+import site.festifriends.domain.member.repository.MemberImageRepository;
+import site.festifriends.entity.MemberImage;
+
+@Service
+@RequiredArgsConstructor
+public class MemberImageService {
+
+
+    private final MemberImageRepository memberImageRepository;
+
+    public void updateProfileImage(Long memberId, ImageDto profileImage) {
+        MemberImage memberImage = memberImageRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다."));
+
+        memberImage.updateImage(profileImage.getSrc(), profileImage.getAlt());
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -183,6 +183,13 @@ public class MemberService {
         );
     }
 
+    public void updateMemberProfile(Long memberId, String name, Integer age, String description, List<String> hashtag,
+        String sns) {
+        Member member = getMemberById(memberId);
+
+        member.updateProfile(name, age, description, hashtag, sns);
+    }
+
     public Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다."));

--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -59,6 +59,8 @@ public class MemberService {
                 .build();
 
             memberImageRepository.save(memberImage);
+
+            return newMember;
         }
 
         return member;

--- a/src/main/java/site/festifriends/domain/member/service/ProfileService.java
+++ b/src/main/java/site/festifriends/domain/member/service/ProfileService.java
@@ -1,0 +1,96 @@
+package site.festifriends.domain.member.service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.festifriends.domain.group.dto.GroupSummaryDto;
+import site.festifriends.domain.group.repository.GroupRepository;
+import site.festifriends.domain.image.dto.ImageDto;
+import site.festifriends.domain.member.dto.GetProfileResponse;
+import site.festifriends.domain.member.repository.MemberRepository;
+import site.festifriends.domain.review.dto.ReviewSummaryDto;
+import site.festifriends.domain.review.repository.ReviewRepository;
+import site.festifriends.entity.enums.ReviewTag;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+
+    private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
+    private final GroupRepository groupRepository;
+
+    public GetProfileResponse getMemberProfile(Long targetId, Long memberId) {
+        Object[] memberData = memberRepository.getMemberProfile(targetId);
+        Object[] extraData = memberRepository.getMemberExtraData(targetId, memberId);
+        Object[] reviewData = reviewRepository.getMemberReviewCount(targetId);
+        List<Object[]> reviewTagData = reviewRepository.countEachReviewTag(targetId);
+        List<String> reviewContents = reviewRepository.getMemberReviewContent(targetId);
+        Object[] groupData = groupRepository.getMemberGroupCount(targetId);
+        
+        Map<ReviewTag, Integer> countMap = new EnumMap<>(ReviewTag.class);
+        for (Object[] row : reviewTagData) {
+            ReviewTag tag = ReviewTag.valueOf((String) row[0]);
+            Integer count = ((Number) row[1]).intValue();
+            countMap.put(tag, count);
+        }
+
+        GroupSummaryDto groupDto = GroupSummaryDto.builder()
+            .joinedCount(groupData != null && groupData[0] != null ? ((Number) groupData[0]).intValue() : 0)
+            .totalJoinedCount(groupData != null && groupData[1] != null ? ((Number) groupData[1]).intValue() : 0)
+            .createdCount(groupData != null && groupData[2] != null ? ((Number) groupData[2]).intValue() : 0)
+            .build();
+
+        ReviewSummaryDto reviewSummaryDto = ReviewSummaryDto.builder()
+            .PUNCTUAL(countMap.getOrDefault(ReviewTag.PUNCTUAL, 0))
+            .POLITE(countMap.getOrDefault(ReviewTag.POLITE, 0))
+            .COMFORTABLE(countMap.getOrDefault(ReviewTag.COMFORTABLE, 0))
+            .COMMUNICATIVE(countMap.getOrDefault(ReviewTag.COMMUNICATIVE, 0))
+            .CLEAN(countMap.getOrDefault(ReviewTag.CLEAN, 0))
+            .RESPONSIVE(countMap.getOrDefault(ReviewTag.RESPONSIVE, 0))
+            .RECOMMEND(countMap.getOrDefault(ReviewTag.RECOMMEND, 0))
+            .build();
+
+        return GetProfileResponse.builder()
+            .id(memberData[0].toString())
+            .name((String) memberData[1])
+            .age((Integer) memberData[2])
+            .gender((String) memberData[3])
+            .profileImage(parseImage((String) memberData[4]))
+            .description((String) memberData[5])
+            .hashtags(memberData[6] == null ? new ArrayList<>() :
+                Arrays.stream(((String) memberData[6]).split(","))
+                    .map(tag -> "#" + tag)
+                    .collect(Collectors.toList()))
+            .sns((String) memberData[7])
+            .isLiked(((Number) extraData[0]).intValue() == 1)
+            .isReported(((Number) extraData[1]).intValue() == 1)
+            .isMine(((Number) extraData[2]).intValue() == 1)
+            .groupSummary(groupDto)
+            .reviewSummary(reviewSummaryDto)
+            .rating(reviewData != null && reviewData[0] != null ? ((Number) reviewData[0]).doubleValue() : 0.0)
+            .reviewCount(reviewData != null && reviewData[1] != null ? ((Number) reviewData[1]).intValue() : 0)
+            .reviewList(reviewContents != null ? reviewContents : new ArrayList<>())
+            .build();
+    }
+
+    private ImageDto parseImage(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        String[] parts = value.split("\\|");
+        String id = parts.length > 0 ? parts[0] : null;
+        String src = parts.length > 1 ? parts[1] : null;
+        String alt = parts.length > 2 ? parts[2] : null;
+        return ImageDto.builder()
+            .id(id)
+            .src(src)
+            .alt(alt)
+            .build();
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/service/ProfileService.java
+++ b/src/main/java/site/festifriends/domain/member/service/ProfileService.java
@@ -8,10 +8,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import site.festifriends.domain.group.dto.GroupSummaryDto;
 import site.festifriends.domain.group.repository.GroupRepository;
 import site.festifriends.domain.image.dto.ImageDto;
+import site.festifriends.domain.member.dto.GetMyProfileResponse;
 import site.festifriends.domain.member.dto.GetProfileResponse;
+import site.festifriends.domain.member.dto.UpdateProfileRequest;
 import site.festifriends.domain.member.repository.MemberRepository;
 import site.festifriends.domain.review.dto.ReviewSummaryDto;
 import site.festifriends.domain.review.repository.ReviewRepository;
@@ -24,7 +27,10 @@ public class ProfileService {
     private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
     private final GroupRepository groupRepository;
+    private final MemberService memberService;
+    private final MemberImageService memberImageService;
 
+    @Transactional(readOnly = true)
     public GetProfileResponse getMemberProfile(Long targetId, Long memberId) {
         Object[] memberData = memberRepository.getMemberProfile(targetId);
         Object[] extraData = memberRepository.getMemberExtraData(targetId, memberId);
@@ -32,7 +38,7 @@ public class ProfileService {
         List<Object[]> reviewTagData = reviewRepository.countEachReviewTag(targetId);
         List<String> reviewContents = reviewRepository.getMemberReviewContent(targetId);
         Object[] groupData = groupRepository.getMemberGroupCount(targetId);
-        
+
         Map<ReviewTag, Integer> countMap = new EnumMap<>(ReviewTag.class);
         for (Object[] row : reviewTagData) {
             ReviewTag tag = ReviewTag.valueOf((String) row[0]);
@@ -77,6 +83,69 @@ public class ProfileService {
             .reviewCount(reviewData != null && reviewData[1] != null ? ((Number) reviewData[1]).intValue() : 0)
             .reviewList(reviewContents != null ? reviewContents : new ArrayList<>())
             .build();
+    }
+
+    @Transactional(readOnly = true)
+    public GetMyProfileResponse getMyProfile(Long memberId) {
+        Object[] memberData = memberRepository.getMemberProfile(memberId);
+        Object[] extraData = memberRepository.getMemberExtraData(memberId, memberId);
+        Object[] reviewData = reviewRepository.getMemberReviewCount(memberId);
+        List<Object[]> reviewTagData = reviewRepository.countEachReviewTag(memberId);
+        List<String> reviewContents = reviewRepository.getMemberReviewContent(memberId);
+        Object[] groupData = groupRepository.getMemberGroupCount(memberId);
+
+        Map<ReviewTag, Integer> countMap = new EnumMap<>(ReviewTag.class);
+        for (Object[] row : reviewTagData) {
+            ReviewTag tag = ReviewTag.valueOf((String) row[0]);
+            Integer count = ((Number) row[1]).intValue();
+            countMap.put(tag, count);
+        }
+
+        GroupSummaryDto groupDto = GroupSummaryDto.builder()
+            .joinedCount(groupData != null && groupData[0] != null ? ((Number) groupData[0]).intValue() : 0)
+            .totalJoinedCount(groupData != null && groupData[1] != null ? ((Number) groupData[1]).intValue() : 0)
+            .createdCount(groupData != null && groupData[2] != null ? ((Number) groupData[2]).intValue() : 0)
+            .build();
+
+        ReviewSummaryDto reviewSummaryDto = ReviewSummaryDto.builder()
+            .PUNCTUAL(countMap.getOrDefault(ReviewTag.PUNCTUAL, 0))
+            .POLITE(countMap.getOrDefault(ReviewTag.POLITE, 0))
+            .COMFORTABLE(countMap.getOrDefault(ReviewTag.COMFORTABLE, 0))
+            .COMMUNICATIVE(countMap.getOrDefault(ReviewTag.COMMUNICATIVE, 0))
+            .CLEAN(countMap.getOrDefault(ReviewTag.CLEAN, 0))
+            .RESPONSIVE(countMap.getOrDefault(ReviewTag.RESPONSIVE, 0))
+            .RECOMMEND(countMap.getOrDefault(ReviewTag.RECOMMEND, 0))
+            .build();
+
+        return GetMyProfileResponse.builder()
+            .id(memberData[0].toString())
+            .name((String) memberData[1])
+            .age((Integer) memberData[2])
+            .gender((String) memberData[3])
+            .profileImage(parseImage((String) memberData[4]))
+            .description((String) memberData[5])
+            .hashtags(memberData[6] == null ? new ArrayList<>() :
+                Arrays.stream(((String) memberData[6]).split(","))
+                    .map(tag -> "#" + tag)
+                    .collect(Collectors.toList()))
+            .sns((String) memberData[7])
+            .isLiked(((Number) extraData[0]).intValue() == 1)
+            .isReported(((Number) extraData[1]).intValue() == 1)
+            .isMine(((Number) extraData[2]).intValue() == 1)
+            .groupSummary(groupDto)
+            .reviewSummary(reviewSummaryDto)
+            .rating(reviewData != null && reviewData[0] != null ? ((Number) reviewData[0]).doubleValue() : 0.0)
+            .reviewCount(reviewData != null && reviewData[1] != null ? ((Number) reviewData[1]).intValue() : 0)
+            .reviewList(reviewContents != null ? reviewContents : new ArrayList<>())
+            .build();
+    }
+
+    @Transactional
+    public void updateMyProfile(Long memberId, UpdateProfileRequest request) {
+        memberService.updateMemberProfile(memberId, request.getName(), request.getAge(), request.getDescription(),
+            request.getHashtag(), request.getSns());
+
+        memberImageService.updateProfileImage(memberId, request.getProfileImage());
     }
 
     private ImageDto parseImage(String value) {

--- a/src/main/java/site/festifriends/domain/review/dto/ReviewSummaryDto.java
+++ b/src/main/java/site/festifriends/domain/review/dto/ReviewSummaryDto.java
@@ -1,0 +1,19 @@
+package site.festifriends.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ReviewSummaryDto {
+
+    private Integer PUNCTUAL;
+    private Integer POLITE;
+    private Integer COMFORTABLE;
+    private Integer COMMUNICATIVE;
+    private Integer CLEAN;
+    private Integer RESPONSIVE;
+    private Integer RECOMMEND;
+}

--- a/src/main/java/site/festifriends/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/review/repository/ReviewRepositoryCustom.java
@@ -40,4 +40,19 @@ public interface ReviewRepositoryCustom {
      * 특정 모임에서 사용자가 리뷰를 작성하지 않은 대상자들 조회
      */
     List<Member> findUnreviewedMembersInGroup(Long userId, Long groupId);
+
+    /**
+     * 특정 사용자의 리뷰 평점 및 리뷰 달린 개수 조회
+     */
+    Object[] getMemberReviewCount(Long targetId);
+
+    /**
+     * 특정 사용자의 리뷰 태그 종류별 개수 조회
+     */
+    List<Object[]> countEachReviewTag(Long targetId);
+
+    /**
+     * 특정 사용자의 리뷰 내용 조회
+     */
+    List<String> getMemberReviewContent(Long targetId);
 }

--- a/src/main/java/site/festifriends/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/review/repository/ReviewRepositoryImpl.java
@@ -177,4 +177,50 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             .setParameter("groupId", groupId)
             .getResultList();
     }
+
+    @Override
+    public Object[] getMemberReviewCount(Long targetId) {
+        String countSql = """
+            SELECT
+                AVG(r.score) AS avgRating,
+                COUNT(*) AS reviewCount
+            FROM review r
+            WHERE r.reviewee_id = :targetId
+            AND r.deleted IS NULL
+            """;
+
+        return (Object[]) entityManager.createNativeQuery(countSql)
+            .setParameter("targetId", targetId)
+            .getSingleResult();
+    }
+
+    @Override
+    public List<Object[]> countEachReviewTag(Long targetId) {
+        String sql = """
+            SELECT rt.tag, COUNT(*) AS tagCount
+            FROM review r
+            JOIN review_tags rt ON r.review_id = rt.review_id
+            WHERE r.reviewee_id = :targetId
+            AND r.deleted IS NULL
+            GROUP BY rt.tag
+            """;
+
+        return entityManager.createNativeQuery(sql)
+            .setParameter("targetId", targetId)
+            .getResultList();
+    }
+
+    @Override
+    public List<String> getMemberReviewContent(Long targetId) {
+        String sql = """
+            SELECT r.content
+            FROM review r
+            WHERE r.reviewee_id = :targetId
+            AND r.deleted IS NULL
+            """;
+
+        return entityManager.createNativeQuery(sql)
+            .setParameter("targetId", targetId)
+            .getResultList();
+    }
 }

--- a/src/main/java/site/festifriends/entity/Member.java
+++ b/src/main/java/site/festifriends/entity/Member.java
@@ -85,4 +85,12 @@ public class Member extends SoftDeleteEntity {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void updateProfile(String name, Integer age, String description, List<String> hashtag, String sns) {
+        this.nickname = name;
+        this.age = age;
+        this.introduction = description;
+        this.tags = hashtag != null ? hashtag : new ArrayList<>();
+        this.sns = sns != null ? List.of(sns) : new ArrayList<>();
+    }
 }

--- a/src/main/java/site/festifriends/entity/MemberImage.java
+++ b/src/main/java/site/festifriends/entity/MemberImage.java
@@ -46,4 +46,8 @@ public class MemberImage extends BaseEntity {
         this.alt = alt;
     }
 
+    public void updateImage(String src, String alt) {
+        this.src = src;
+        this.alt = alt;
+    }
 }

--- a/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/site/festifriends/domain/member/repository/MemberRepositoryTest.java
@@ -257,4 +257,42 @@ public class MemberRepositoryTest {
         assertThat(dto2.getEndDate()).isEqualTo(LocalDateTime.of(2025, 6, 1, 22, 0));
         assertThat(dto2.getPoster()).isEqualTo("https://example.com/poster1.jpg");
     }
+
+    @Test
+    @DisplayName("[성공] 회원 프로필 기본 정보 조회")
+    void getMemberProfile() {
+        // given
+        Long targetId = member.getId();
+
+        // when
+        Object[] result = memberRepositoryImpl.getMemberProfile(targetId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result[0]).isEqualTo(member.getId());
+        assertThat(result[1]).isEqualTo(member.getNickname());
+        assertThat(result[2]).isEqualTo(member.getAge());
+        assertThat(result[3]).isEqualTo(member.getGender().name());
+        assertThat(result[4]).isEqualTo(
+            memberImage.getId() + "|" + memberImage.getSrc() + "|" + memberImage.getAlt());
+        assertThat(result[5]).isEqualTo(member.getIntroduction());
+    }
+
+    @Test
+    @DisplayName("[성공] 회원 좋아요 여부, 신고 여부, 본인 여부 테스트")
+    void getMemberExtraData() {
+        // given
+        Long targetId = target1.getId();
+        Long memberId = member.getId();
+
+        // when
+        Object[] result = memberRepositoryImpl.getMemberExtraData(memberId, targetId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result[0]).isEqualTo(1); // 좋아요 여부
+        assertThat(result[1]).isEqualTo(0); // 신고 여부
+        assertThat(result[2]).isEqualTo(0); // 본인 여부
+    }
+
 }

--- a/src/test/java/site/festifriends/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/site/festifriends/domain/review/repository/ReviewRepositoryTest.java
@@ -1,0 +1,152 @@
+package site.festifriends.domain.review.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import site.festifriends.common.config.AuditConfig;
+import site.festifriends.common.config.QueryDslConfig;
+import site.festifriends.domain.group.repository.GroupRepository;
+import site.festifriends.domain.member.repository.MemberRepository;
+import site.festifriends.entity.Group;
+import site.festifriends.entity.Member;
+import site.festifriends.entity.Review;
+import site.festifriends.entity.enums.Gender;
+import site.festifriends.entity.enums.GroupCategory;
+import site.festifriends.entity.enums.ReviewTag;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, AuditConfig.class})
+@ActiveProfiles("test")
+class ReviewRepositoryTest {
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    private Member reviewer;
+    private Member reviewee;
+    private Group group;
+    private Review review1;
+    private Review review2;
+
+    @BeforeEach
+    void setUp() {
+        reviewer = memberRepository.save(Member.builder()
+            .email("reviewer@example.com")
+            .nickname("리뷰어")
+            .age(28)
+            .gender(Gender.MALE)
+            .introduction("리뷰어입니다")
+            .tags(List.of("음악", "여행"))
+            .sns(List.of("github", "instagram"))
+            .socialId("socialId1")
+            .build());
+
+        reviewee = memberRepository.save(Member.builder()
+            .email("reviewee@example.com")
+            .nickname("리뷰이")
+            .age(28)
+            .gender(Gender.MALE)
+            .introduction("리뷰이입니다")
+            .tags(List.of("피아노", "기타"))
+            .sns(List.of("github", "instagram"))
+            .socialId("socialId2")
+            .build());
+
+        group = groupRepository.save(Group.builder()
+            .title("테스트 그룹")
+            .genderType(Gender.ALL)
+            .startAge(20)
+            .endAge(90)
+            .gatherType(GroupCategory.COMPANION)
+            .startDate(java.time.LocalDateTime.now())
+            .endDate(java.time.LocalDateTime.now().plusDays(1))
+            .location("테스트 장소")
+            .count(10)
+            .introduction("테스트 소개")
+            .build());
+
+        review1 = reviewRepository.save(Review.builder()
+            .reviewer(reviewer)
+            .reviewee(reviewee)
+            .group(group)
+            .content("리뷰 내용 1")
+            .score(3.5)
+            .tags(List.of(ReviewTag.COMFORTABLE, ReviewTag.CLEAN))
+            .build());
+
+        review2 = reviewRepository.save(Review.builder()
+            .reviewer(reviewer)
+            .reviewee(reviewee)
+            .group(group)
+            .content("리뷰 내용 2")
+            .score(4.0)
+            .tags(List.of(ReviewTag.COMFORTABLE, ReviewTag.RESPONSIVE))
+            .build());
+    }
+
+    @Test
+    @DisplayName("[성공] 타겟 회원 리뷰 개수 조회")
+    void countReviewsByTargetMember() {
+        // given
+        Long targetMemberId = reviewee.getId();
+
+        // when
+        Object[] count = reviewRepository.getMemberReviewCount(targetMemberId);
+
+        // then
+        assertThat(((BigDecimal) count[0]).doubleValue()).isEqualTo(3.75);
+        assertThat(count[1]).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("[성공] 타겟 회원 리뷰 태그 개수 조회")
+    void countEachReviewTagByTargetMember() {
+        // given
+        Long targetMemberId = reviewee.getId();
+
+        // when
+        List<Object[]> tagCounts = reviewRepository.countEachReviewTag(targetMemberId);
+        Map<ReviewTag, Integer> tagCountMap = new EnumMap<>(ReviewTag.class);
+        for (Object[] row : tagCounts) {
+            ReviewTag tag = ReviewTag.valueOf((String) row[0]);
+            Integer count = ((Number) row[1]).intValue();
+            tagCountMap.put(tag, count);
+        }
+
+        // then
+        assertThat(tagCounts).hasSize(3);
+        assertThat(tagCountMap.get(ReviewTag.COMFORTABLE)).isEqualTo(2);
+        assertThat(tagCountMap.get(ReviewTag.CLEAN)).isEqualTo(1);
+        assertThat(tagCountMap.get(ReviewTag.RESPONSIVE)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("[성공] 타겟 회원 리뷰 내용 조회")
+    void getReviewContentByTargetMember() {
+        // given
+        Long targetMemberId = reviewee.getId();
+
+        // when
+        List<String> reviewContents = reviewRepository.getMemberReviewContent(targetMemberId);
+
+        // then
+        assertThat(reviewContents).hasSize(2);
+        assertThat(reviewContents).containsExactlyInAnyOrder("리뷰 내용 1", "리뷰 내용 2");
+    }
+}


### PR DESCRIPTION
- [✨feat: 프로필 홈 조회 기능 작성](https://github.com/FestiFriends/ff_backend/commit/b0700c99229a219c34b85b53d399113241bbb422)
  - 프로필 홈에 대한 응답에 member, review, image, group 등 집계함수와 여러 도메인이 섞여 있어 쿼리를 나누어 진행하였습니다.
  - ReviewTag의 경우 enumMap을 통해 enum의 개수를 파악하고, 존재하지 않을 경우 0으로 return할 수 있도록 했습니다.
  - 유저가 참여,개설한 모임을 count하기 위해 GroupRepositoryCusom을 추가하였습니다.
  - securitConfig 설정을 통해, 다른 회원의 프로필 조회의 경우는 인증이 없어도 가능하도록, 내 프로필 조회는 인증이 필요하도록 설정하였습니다. (`.requestMatchers(HttpMethod.GET, "/api/v1/profiles/me").authenticated()`)
  - 내 프로필 조회의 경우 targetId를 현재 로그인 중인 아이디와 동일하게 하여 코드의 재사용성을 높였습니다.
  - 또한, `@JsonIgnore`어노테이션을 통해 불필요한 응답을 보내지 않도록 했습니다.
- [✨feat: 회원 프로필 수정 기능 구현](https://github.com/FestiFriends/ff_backend/commit/ae6c9d5128b70cdc7a198f9b1455b7992f61bdc6)
  - Spring JPA의 더티체킹을 기반으로 update가 진행되도록 하였습니다.
  - 회원, 회원 이미지 로직을 하나의 트랜잭션으로 관리해 데이터가 일관되게 저장되도록 설정했습니다.