### PR TITLE
✨feat: 사용자 찜하기/취소 기능 구현

### DIFF
--- a/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
@@ -6,8 +6,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.member.dto.ToggleUserLikeRequest;
 
 public interface MemberApi {
 
@@ -61,5 +64,23 @@ public interface MemberApi {
         @RequestParam(required = false) Long cursorId,
         @Parameter(description = "한 페이지당 항목 수, default는 20")
         @RequestParam(defaultValue = "20") int size
+    );
+
+    @Operation(
+        summary = "사용자 찜하기/취소",
+        description = "사용자를 찜하거나 찜을 취소합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "사용자 찜하기/취소 성공"),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 회원입니다."),
+            @ApiResponse(responseCode = "400", description = "이미 찜한 사용자를 찜할 수 없습니다."),
+            @ApiResponse(responseCode = "400", description = "찜하지 않은 사용자를 찜 취소할 수 없습니다."),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> toggleLikeMember(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Parameter(description = "찜할 사용자 ID")
+        @PathVariable Long memberId,
+        @RequestBody ToggleUserLikeRequest request
     );
 }

--- a/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
@@ -70,7 +70,8 @@ public interface MemberApi {
         summary = "사용자 찜하기/취소",
         description = "사용자를 찜하거나 찜을 취소합니다.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "사용자 찜하기/취소 성공"),
+            @ApiResponse(responseCode = "200", description = "사용자를 찜했습니다"),
+            @ApiResponse(responseCode = "200", description = "사용자를 찜 취소했습니다"),
             @ApiResponse(responseCode = "400", description = "존재하지 않는 회원입니다."),
             @ApiResponse(responseCode = "400", description = "이미 찜한 사용자를 찜할 수 없습니다."),
             @ApiResponse(responseCode = "400", description = "찜하지 않은 사용자를 찜 취소할 수 없습니다."),

--- a/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberApi.java
@@ -41,7 +41,7 @@ public interface MemberApi {
         summary = "내가 찜한 사용자 수",
         description = "내가 찜한 사용자 수를 조회합니다.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "찜한 사용자 삭제 성공"),
+            @ApiResponse(responseCode = "200", description = "요청이 성공적으로 처리되었습니다."),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
         }
     )
@@ -51,7 +51,7 @@ public interface MemberApi {
         summary = "찜한 공연 목록 조회",
         description = "내가 찜한 공연 목록을 조회합니다.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "찜한 사용자 삭제 성공"),
+            @ApiResponse(responseCode = "200", description = "요청이 성공적으로 처리되었습니다."),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
         }
     )

--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -6,6 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,6 +17,8 @@ import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.member.dto.LikedMemberCountResponse;
 import site.festifriends.domain.member.dto.LikedMemberResponse;
+import site.festifriends.domain.member.dto.ToggleUserLikeRequest;
+import site.festifriends.domain.member.dto.ToggleUserLikeResponse;
 import site.festifriends.domain.member.service.MemberService;
 
 @RestController
@@ -63,5 +68,22 @@ public class MemberController implements MemberApi {
                 "요청이 성공적으로 처리되었습니다.",
                 memberService.getMyLikedPerformances(userDetails.getMemberId(), cursorId, size)
             ));
+    }
+
+    @Override
+    @PatchMapping("/favorites/{userId}")
+    public ResponseEntity<?> toggleLikeMember(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable Long userId,
+        @RequestBody ToggleUserLikeRequest request
+    ) {
+        boolean like = request.getIsLiked();
+        ToggleUserLikeResponse response = memberService.toggleLikeMember(userDetails.getMemberId(), userId, like);
+
+        if (like) {
+            return ResponseEntity.ok(ResponseWrapper.success("사용자를 찜했습니다", response));
+        } else {
+            return ResponseEntity.ok(ResponseWrapper.success("사용자를 찜 취소했습니다", response));
+        }
     }
 }

--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -58,6 +58,10 @@ public class MemberController implements MemberApi {
         @RequestParam(required = false) Long cursorId,
         @RequestParam(defaultValue = "20") int size
     ) {
-        return ResponseEntity.ok(memberService.getMyLikedPerformances(userDetails.getMemberId(), cursorId, size));
+        return ResponseEntity.ok(
+            ResponseWrapper.success(
+                "요청이 성공적으로 처리되었습니다.",
+                memberService.getMyLikedPerformances(userDetails.getMemberId(), cursorId, size)
+            ));
     }
 }

--- a/src/main/java/site/festifriends/domain/member/dto/ToggleUserLikeRequest.java
+++ b/src/main/java/site/festifriends/domain/member/dto/ToggleUserLikeRequest.java
@@ -1,0 +1,14 @@
+package site.festifriends.domain.member.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ToggleUserLikeRequest {
+
+    @NotEmpty
+    private Boolean isLiked;
+
+}

--- a/src/main/java/site/festifriends/domain/member/dto/ToggleUserLikeRequest.java
+++ b/src/main/java/site/festifriends/domain/member/dto/ToggleUserLikeRequest.java
@@ -1,6 +1,6 @@
 package site.festifriends.domain.member.dto;
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ToggleUserLikeRequest {
 
-    @NotEmpty
+    @NotNull
     private Boolean isLiked;
 
 }

--- a/src/main/java/site/festifriends/domain/member/dto/ToggleUserLikeResponse.java
+++ b/src/main/java/site/festifriends/domain/member/dto/ToggleUserLikeResponse.java
@@ -1,0 +1,15 @@
+package site.festifriends.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ToggleUserLikeResponse {
+
+    @JsonProperty("isLiked")
+    private Boolean isLiked;
+    private Long userId;
+
+}


### PR DESCRIPTION
- [📝docs: 회원 기능 컨트롤러 응답 잘못 설정되어 있던 부분 수정](https://github.com/FestiFriends/ff_backend/commit/f2f333f15b84f1e7e269c51df0bab9af7441917f)
  - 컨트롤러 응답이 정상적으로 설정되어 있지 않은 문제를 수정했습니다.

- [✨feat: 사용자 찜하기/취소 기능 작성](https://github.com/FestiFriends/ff_backend/commit/a823275f238ca5dea309a58fe84261b2b86aa526)
  - 사용자 찜하기/취소 기능의 경우 조건에 따라 응답이 달라지는 형태이기 때문에 이를 반영하였습니다.
  - 서비스 로직 내 `@Transactional` 을 통해 트랜잭션 관리를 하도록 변경하였습니다.