### PR TITLE
✨feat: 알림 기능 관련 api 작성

### DIFF
--- a/src/main/java/site/festifriends/domain/application/repository/ApplicationRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/application/repository/ApplicationRepositoryCustom.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import site.festifriends.entity.Member;
 import site.festifriends.entity.MemberGroup;
 import site.festifriends.entity.enums.Role;
 
@@ -35,4 +36,8 @@ public interface ApplicationRepositoryCustom {
     Optional<MemberGroup> findByGroupIdAndMemberId(Long groupId, Long memberId);
 
     Optional<MemberGroup> findByGroupIdAndRole(Long groupId, Role role);
-} 
+
+    Optional<Member> findHostByGroupId(Long groupId);
+
+    List<Member> findMembersByGroupId(Long groupId);
+}

--- a/src/main/java/site/festifriends/domain/application/repository/ApplicationRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/application/repository/ApplicationRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
+import site.festifriends.entity.Member;
 import site.festifriends.entity.MemberGroup;
 import site.festifriends.entity.QGroup;
 import site.festifriends.entity.QMember;
@@ -397,6 +398,52 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
             .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Optional<Member> findHostByGroupId(Long groupId) {
+        if (groupId == null) {
+            return Optional.empty();
+        }
+
+        QMemberGroup mg = QMemberGroup.memberGroup;
+        QMember m = QMember.member;
+
+        Member host = queryFactory
+            .select(m)
+            .from(m)
+            .leftJoin(mg).on(mg.member.id.eq(m.id))
+            .where(
+                mg.group.id.eq(groupId),
+                mg.role.eq(Role.HOST),
+                mg.deleted.isNull()
+            )
+            .fetchOne();
+
+        return Optional.ofNullable(host);
+    }
+
+    @Override
+    public List<Member> findMembersByGroupId(Long groupId) {
+        if (groupId == null) {
+            return Collections.emptyList();
+        }
+
+        QMemberGroup mg = QMemberGroup.memberGroup;
+        QMember m = QMember.member;
+
+        List<Member> members = queryFactory
+            .select(m)
+            .from(m)
+            .join(mg).on(mg.member.id.eq(m.id))
+            .where(
+                mg.group.id.eq(groupId),
+                mg.status.eq(ApplicationStatus.CONFIRMED),
+                mg.deleted.isNull()
+            )
+            .fetch();
+
+        return members;
     }
 
     private BooleanExpression cursorIdLt(Long cursorId, QMemberGroup memberGroup) {

--- a/src/main/java/site/festifriends/domain/notifications/NotificationSender.java
+++ b/src/main/java/site/festifriends/domain/notifications/NotificationSender.java
@@ -1,0 +1,8 @@
+package site.festifriends.domain.notifications;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationSender {
+
+}

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import site.festifriends.common.response.CursorResponseWrapper;
@@ -36,5 +37,55 @@ public interface NotificationApi {
     )
     ResponseEntity<SseEmitter> subscribe(
         @AuthenticationPrincipal UserDetailsImpl userDetails
+    );
+
+    @Operation(
+        summary = "모든 알림 읽음 처리",
+        description = "모든 알림을 읽음 처리합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "모든 알림을 읽음 처리하였습니다."),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> readAllNotifications(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    );
+
+    @Operation(
+        summary = "개발 알림 읽음 처리",
+        description = "개발 알림을 읽음 처리합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "알림을 읽음 처리하였습니다."),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> readNotification(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable Long notificationId
+    );
+
+    @Operation(
+        summary = "알림 전체 삭제",
+        description = "모든 알림을 삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "모든 알림을 삭제하였습니다."),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> deleteAllNotifications(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    );
+
+    @Operation(
+        summary = "알림 개발 삭제",
+        description = "개발 알림을 삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "알림을 삭제하였습니다."),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> deleteNotification(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam Long notificationId
     );
 }

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
@@ -86,6 +86,6 @@ public interface NotificationApi {
     )
     ResponseEntity<?> deleteNotification(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @RequestParam Long notificationId
+        @PathVariable Long notificationId
     );
 }

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
@@ -77,8 +77,8 @@ public interface NotificationApi {
     );
 
     @Operation(
-        summary = "알림 개발 삭제",
-        description = "개발 알림을 삭제합니다.",
+        summary = "알림 개별 삭제",
+        description = "개별 알림을 삭제합니다.",
         responses = {
             @ApiResponse(responseCode = "200", description = "알림을 삭제하였습니다."),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
@@ -87,5 +87,17 @@ public interface NotificationApi {
     ResponseEntity<?> deleteNotification(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable Long notificationId
+    );
+
+    @Operation(
+        summary = "새로운 알림 조회",
+        description = "회원이 읽지 않은 새로운 알림이 있는지 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "알림 상태를 확인했습니다."),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> existUnreadNotification(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
     );
 }

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
@@ -1,0 +1,27 @@
+package site.festifriends.domain.notifications.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.notifications.dto.GetNotificationsResponse;
+
+public interface NotificationApi {
+
+    @Operation(
+        summary = "알림 조회",
+        description = "커서 기반으로 알림을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "알림 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<CursorResponseWrapper<GetNotificationsResponse>> getNotifications(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam(required = false) Long cursorId,
+        @RequestParam(defaultValue = "20") int size
+    );
+}

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationApi.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.notifications.dto.GetNotificationsResponse;
@@ -23,5 +24,17 @@ public interface NotificationApi {
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestParam(required = false) Long cursorId,
         @RequestParam(defaultValue = "20") int size
+    );
+
+    @Operation(
+        summary = "알림 구독",
+        description = "알림을 실시간으로 구독합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "알림 구독 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<SseEmitter> subscribe(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
     );
 }

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
@@ -15,6 +15,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.notifications.dto.ExistUnreadNotificationResponse;
 import site.festifriends.domain.notifications.dto.GetNotificationsResponse;
 import site.festifriends.domain.notifications.service.NotificationService;
 
@@ -81,5 +82,20 @@ public class NotificationController implements NotificationApi {
         return ResponseEntity.ok(ResponseWrapper.success("알림을 삭제하였습니다."));
     }
 
+    @Override
+    @GetMapping("/unread-exists")
+    public ResponseEntity<?> existUnreadNotification(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        boolean exists = notificationService.existUnreadNotification(userDetails.getMemberId());
 
+        ExistUnreadNotificationResponse response = ExistUnreadNotificationResponse.builder()
+            .hasUnread(exists)
+            .build();
+
+        return ResponseEntity.ok(ResponseWrapper.success(
+            "알림 상태를 확인했습니다.",
+            response
+        ));
+    }
 }

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
@@ -1,0 +1,31 @@
+package site.festifriends.domain.notifications.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.notifications.dto.GetNotificationsResponse;
+import site.festifriends.domain.notifications.service.NotificationService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController implements NotificationApi {
+
+    private final NotificationService notificationService;
+
+    @Override
+    @GetMapping("")
+    public ResponseEntity<CursorResponseWrapper<GetNotificationsResponse>> getNotifications(UserDetailsImpl userDetails,
+        Long cursorId, int size) {
+        return ResponseEntity.ok(notificationService.getNotifications(userDetails.getMemberId(), cursorId, size));
+    }
+
+//    @Override
+//    public ResponseEntity<SseEmitter> subscribe(UserDetailsImpl userDetails) {
+//        return null;
+//    }
+}

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
@@ -1,10 +1,12 @@
 package site.festifriends.domain.notifications.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.notifications.dto.GetNotificationsResponse;
@@ -24,8 +26,9 @@ public class NotificationController implements NotificationApi {
         return ResponseEntity.ok(notificationService.getNotifications(userDetails.getMemberId(), cursorId, size));
     }
 
-//    @Override
-//    public ResponseEntity<SseEmitter> subscribe(UserDetailsImpl userDetails) {
-//        return null;
-//    }
+    @Override
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> subscribe(UserDetailsImpl userDetails) {
+        return ResponseEntity.ok(notificationService.subscribe(userDetails.getMemberId()));
+    }
 }

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
@@ -3,11 +3,17 @@ package site.festifriends.domain.notifications.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.notifications.dto.GetNotificationsResponse;
 import site.festifriends.domain.notifications.service.NotificationService;
@@ -21,14 +27,59 @@ public class NotificationController implements NotificationApi {
 
     @Override
     @GetMapping("")
-    public ResponseEntity<CursorResponseWrapper<GetNotificationsResponse>> getNotifications(UserDetailsImpl userDetails,
-        Long cursorId, int size) {
+    public ResponseEntity<CursorResponseWrapper<GetNotificationsResponse>> getNotifications(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam(required = false) Long cursorId,
+        @RequestParam(defaultValue = "20") int size
+    ) {
         return ResponseEntity.ok(notificationService.getNotifications(userDetails.getMemberId(), cursorId, size));
     }
 
     @Override
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> subscribe(UserDetailsImpl userDetails) {
+    public ResponseEntity<SseEmitter> subscribe(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
         return ResponseEntity.ok(notificationService.subscribe(userDetails.getMemberId()));
     }
+
+    @Override
+    @PatchMapping("")
+    public ResponseEntity<?> readAllNotifications(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        notificationService.readAllNotifications(userDetails.getMemberId());
+        return ResponseEntity.ok(ResponseWrapper.success("모든 알림을 읽음 처리하였습니다."));
+    }
+
+    @Override
+    @PatchMapping("/{notificationId}")
+    public ResponseEntity<?> readNotification(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable Long notificationId
+    ) {
+        notificationService.readNotification(userDetails.getMemberId(), notificationId);
+        return ResponseEntity.ok(ResponseWrapper.success("알림을 읽음 처리하였습니다."));
+    }
+
+    @Override
+    @DeleteMapping("")
+    public ResponseEntity<?> deleteAllNotifications(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        notificationService.deleteAllNotifications(userDetails.getMemberId());
+        return ResponseEntity.ok(ResponseWrapper.success("모든 알림을 삭제하였습니다."));
+    }
+
+    @Override
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<?> deleteNotification(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam Long notificationId
+    ) {
+        notificationService.deleteNotification(userDetails.getMemberId(), notificationId);
+        return ResponseEntity.ok(ResponseWrapper.success("알림을 삭제하였습니다."));
+    }
+
+
 }

--- a/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/site/festifriends/domain/notifications/controller/NotificationController.java
@@ -75,7 +75,7 @@ public class NotificationController implements NotificationApi {
     @DeleteMapping("/{notificationId}")
     public ResponseEntity<?> deleteNotification(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @RequestParam Long notificationId
+        @PathVariable Long notificationId
     ) {
         notificationService.deleteNotification(userDetails.getMemberId(), notificationId);
         return ResponseEntity.ok(ResponseWrapper.success("알림을 삭제하였습니다."));

--- a/src/main/java/site/festifriends/domain/notifications/dto/ExistUnreadNotificationResponse.java
+++ b/src/main/java/site/festifriends/domain/notifications/dto/ExistUnreadNotificationResponse.java
@@ -1,0 +1,13 @@
+package site.festifriends.domain.notifications.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExistUnreadNotificationResponse {
+
+    @JsonProperty("hasUnread")
+    private Boolean hasUnread;
+}

--- a/src/main/java/site/festifriends/domain/notifications/dto/GetNotificationsResponse.java
+++ b/src/main/java/site/festifriends/domain/notifications/dto/GetNotificationsResponse.java
@@ -1,6 +1,8 @@
 package site.festifriends.domain.notifications.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +13,19 @@ public class GetNotificationsResponse {
 
     private Long id;
     private String message;
+    private String type;
+    private TargetDto target;
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
     private LocalDateTime createdAt;
+    @JsonProperty("isRead")
+    private Boolean isRead;
+
+    @Getter
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class TargetDto {
+
+        private Long postId;
+        private Long groupId;
+    }
 }

--- a/src/main/java/site/festifriends/domain/notifications/dto/GetNotificationsResponse.java
+++ b/src/main/java/site/festifriends/domain/notifications/dto/GetNotificationsResponse.java
@@ -1,0 +1,16 @@
+package site.festifriends.domain.notifications.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetNotificationsResponse {
+
+    private Long id;
+    private String message;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/site/festifriends/domain/notifications/dto/NotificationDto.java
+++ b/src/main/java/site/festifriends/domain/notifications/dto/NotificationDto.java
@@ -10,5 +10,9 @@ public class NotificationDto {
 
     private Long id;
     private String message;
+    private String type;
     private LocalDateTime createdAt;
+    private Boolean isRead;
+    private Long targetId;
+    private Long subTargetId;
 }

--- a/src/main/java/site/festifriends/domain/notifications/dto/NotificationDto.java
+++ b/src/main/java/site/festifriends/domain/notifications/dto/NotificationDto.java
@@ -1,0 +1,14 @@
+package site.festifriends.domain.notifications.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationDto {
+
+    private Long id;
+    private String message;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/site/festifriends/domain/notifications/dto/NotificationEvent.java
+++ b/src/main/java/site/festifriends/domain/notifications/dto/NotificationEvent.java
@@ -1,0 +1,13 @@
+package site.festifriends.domain.notifications.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationEvent {
+
+    private final String message;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepository.java
@@ -23,4 +23,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying
     @Query("UPDATE Notification n SET n.deleted = CURRENT_TIMESTAMP WHERE n.member.id = :memberId AND n.id = :notificationId")
     int deleteNotification(Long memberId, Long notificationId);
+
+    boolean existsByMemberIdAndIsReadFalseAndDeletedIsNull(Long memberId);
 }

--- a/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package site.festifriends.domain.notifications.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+
+}

--- a/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepository.java
@@ -1,8 +1,26 @@
 package site.festifriends.domain.notifications.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import site.festifriends.entity.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.member.id = :memberId AND n.isRead = false")
+    int readAllNotifications(Long memberId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.member.id = :memberId AND n.id = :notificationId")
+    int readNotification(Long memberId, Long notificationId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.deleted = CURRENT_TIMESTAMP WHERE n.member.id = :memberId")
+    int deleteAllNotifications(Long memberId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.deleted = CURRENT_TIMESTAMP WHERE n.member.id = :memberId AND n.id = :notificationId")
+    int deleteNotification(Long memberId, Long notificationId);
 }

--- a/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package site.festifriends.domain.notifications.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import site.festifriends.domain.notifications.dto.NotificationDto;
+
+public interface NotificationRepositoryCustom {
+
+    Slice<NotificationDto> getNotifications(Long memberId, Long cursorId, Pageable pageable);
+
+}

--- a/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,54 @@
+package site.festifriends.domain.notifications.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import site.festifriends.domain.notifications.dto.NotificationDto;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+
+    private final EntityManager em;
+
+    @Override
+    public Slice<NotificationDto> getNotifications(Long memberId, Long cursorId, Pageable pageable) {
+        int pageSize = pageable.getPageSize() + 1;
+
+        String sql = """
+            SELECT n.notification_id, n.message, n.created_at
+            FROM notification n
+            WHERE n.member_id = :memberId
+            AND n.is_read = false
+            AND (:cursorId IS NULL OR n.notification_id <= :cursorId)
+            ORDER BY n.notification_id DESC
+            LIMIT :size
+            """;
+
+        Query query = em.createNativeQuery(sql);
+
+        query.setParameter("memberId", memberId);
+        query.setParameter("cursorId", cursorId);
+        query.setParameter("size", pageSize);
+
+        List<Object[]> results = query.getResultList();
+
+        List<NotificationDto> notifications = results.stream()
+            .map(result -> NotificationDto.builder()
+                .id(((Number) result[0]).longValue())
+                .message((String) result[1])
+                .createdAt(((Timestamp) result[2]).toLocalDateTime())
+                .build())
+            .toList();
+
+        boolean hasNext = notifications.size() == pageSize;
+
+        return new SliceImpl<>(notifications, pageable, hasNext);
+    }
+}

--- a/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryImpl.java
@@ -22,7 +22,7 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom 
         int pageSize = pageable.getPageSize() + 1;
 
         String sql = """
-            SELECT n.notification_id, n.message, n.created_at
+            SELECT n.notification_id, n.message, n.type ,n.created_at, n.is_read, n.target_id, n.sub_target_id
             FROM notification n
             WHERE n.member_id = :memberId
             AND n.is_read = false
@@ -43,7 +43,11 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom 
             .map(result -> NotificationDto.builder()
                 .id(((Number) result[0]).longValue())
                 .message((String) result[1])
-                .createdAt(((Timestamp) result[2]).toLocalDateTime())
+                .type((String) result[2])
+                .createdAt(((Timestamp) result[3]).toLocalDateTime())
+                .isRead((Boolean) result[4])
+                .targetId(((Number) result[5]).longValue())
+                .subTargetId(result[6] != null ? ((Number) result[6]).longValue() : null)
                 .build())
             .toList();
 

--- a/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
+++ b/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
@@ -1,22 +1,31 @@
 package site.festifriends.domain.notifications.service;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.domain.notifications.dto.GetNotificationsResponse;
 import site.festifriends.domain.notifications.dto.NotificationDto;
 import site.festifriends.domain.notifications.repository.NotificationRepository;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
 
     public CursorResponseWrapper<GetNotificationsResponse> getNotifications(Long memberId, Long cursorId, int size) {
         Pageable pageable = PageRequest.of(0, size);
@@ -49,5 +58,35 @@ public class NotificationService {
             nextCursorId,
             slice.hasNext()
         );
+    }
+
+    public SseEmitter subscribe(Long memberId) {
+        SseEmitter oldEmitter = emitters.get(memberId);
+        if (oldEmitter != null) {
+            oldEmitter.complete();
+            emitters.remove(memberId);
+        }
+
+        SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitters.put(memberId, sseEmitter);
+
+        sseEmitter.onCompletion(() -> emitters.remove(memberId));
+        sseEmitter.onTimeout(() -> emitters.remove(memberId));
+        sseEmitter.onError((ex) -> {
+            emitters.remove(memberId);
+            log.error("SSE connection error for member: {}", memberId, ex);
+        });
+
+        try {
+            sseEmitter.send(SseEmitter.event()
+                .name("connect")
+                .data("연결이 성공되었습니다."));
+        } catch (IOException e) {
+            log.error("Failed to send initial message", e);
+            emitters.remove(memberId);
+            sseEmitter.completeWithError(e);
+        }
+
+        return sseEmitter;
     }
 }

--- a/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
+++ b/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
@@ -11,7 +11,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import site.festifriends.common.exception.BusinessException;
+import site.festifriends.common.exception.ErrorCode;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.domain.notifications.dto.GetNotificationsResponse;
 import site.festifriends.domain.notifications.dto.GetNotificationsResponse.TargetDto;
@@ -113,5 +116,31 @@ public class NotificationService {
         }
 
         return null;
+    }
+
+    @Transactional
+    public void readAllNotifications(Long memberId) {
+        notificationRepository.readAllNotifications(memberId);
+    }
+
+    @Transactional
+    public void readNotification(Long memberId, Long notificationId) {
+        if (!notificationRepository.existsById(notificationId)) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "알림이 존재하지 않습니다.");
+        }
+        notificationRepository.readNotification(memberId, notificationId);
+    }
+
+    @Transactional
+    public void deleteAllNotifications(Long memberId) {
+        notificationRepository.deleteAllNotifications(memberId);
+    }
+
+    @Transactional
+    public void deleteNotification(Long memberId, Long notificationId) {
+        if (!notificationRepository.existsById(notificationId)) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "알림이 존재하지 않습니다.");
+        }
+        notificationRepository.deleteNotification(memberId, notificationId);
     }
 }

--- a/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
+++ b/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
@@ -123,8 +123,11 @@ public class NotificationService {
         }
     }
 
-    public void sendNotifications(List<Member> members, NotificationEvent event) {
+    public void sendNotifications(List<Member> members, NotificationEvent event, Long writerId) {
         for (Member member : members) {
+            if (member.getId().equals(writerId)) {
+                continue;
+            }
             SseEmitter emitter = emitters.get(member.getId());
             if (emitter != null) {
                 try {

--- a/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
+++ b/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
@@ -144,6 +144,7 @@ public class NotificationService {
         notificationRepository.deleteNotification(memberId, notificationId);
     }
 
+    @Transactional(readOnly = true)
     public boolean existUnreadNotification(Long memberId) {
         return notificationRepository.existsByMemberIdAndIsReadFalseAndDeletedIsNull(memberId);
     }

--- a/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
+++ b/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
@@ -1,0 +1,53 @@
+package site.festifriends.domain.notifications.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.notifications.dto.GetNotificationsResponse;
+import site.festifriends.domain.notifications.dto.NotificationDto;
+import site.festifriends.domain.notifications.repository.NotificationRepository;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public CursorResponseWrapper<GetNotificationsResponse> getNotifications(Long memberId, Long cursorId, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        Slice<NotificationDto> slice = notificationRepository.getNotifications(memberId, cursorId, pageable);
+
+        if (slice.isEmpty()) {
+            return CursorResponseWrapper.empty("알림 조회 성공");
+        }
+
+        List<GetNotificationsResponse> response = new ArrayList<>();
+
+        for (NotificationDto notification : slice.getContent()) {
+            response.add(GetNotificationsResponse.builder()
+                .id(notification.getId())
+                .message(notification.getMessage())
+                .createdAt(notification.getCreatedAt())
+                .build());
+        }
+
+        Long nextCursorId = null;
+        if (slice.hasNext()) {
+            response.remove(response.size() - 1);
+            nextCursorId = slice.getContent().get(size).getId();
+        }
+
+        return CursorResponseWrapper.success(
+            "알림 조회 성공",
+            response,
+            nextCursorId,
+            slice.hasNext()
+        );
+    }
+}

--- a/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
+++ b/src/main/java/site/festifriends/domain/notifications/service/NotificationService.java
@@ -143,4 +143,8 @@ public class NotificationService {
         }
         notificationRepository.deleteNotification(memberId, notificationId);
     }
+
+    public boolean existUnreadNotification(Long memberId) {
+        return notificationRepository.existsByMemberIdAndIsReadFalseAndDeletedIsNull(memberId);
+    }
 }

--- a/src/main/java/site/festifriends/domain/post/service/PostService.java
+++ b/src/main/java/site/festifriends/domain/post/service/PostService.java
@@ -142,7 +142,7 @@ public class PostService {
             groupId
         );
 
-        notificationService.sendNotifications(members, event);
+        notificationService.sendNotifications(members, event, memberId);
 
         return PostCreateResponse.success();
     }

--- a/src/main/java/site/festifriends/domain/post/service/PostService.java
+++ b/src/main/java/site/festifriends/domain/post/service/PostService.java
@@ -13,6 +13,8 @@ import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.domain.application.repository.ApplicationRepository;
 import site.festifriends.domain.group.repository.GroupRepository;
 import site.festifriends.domain.member.repository.MemberRepository;
+import site.festifriends.domain.notifications.dto.NotificationEvent;
+import site.festifriends.domain.notifications.service.NotificationService;
 import site.festifriends.domain.post.dto.PostCreateRequest;
 import site.festifriends.domain.post.dto.PostCreateResponse;
 import site.festifriends.domain.post.dto.PostListRequest;
@@ -29,6 +31,7 @@ import site.festifriends.entity.Member;
 import site.festifriends.entity.Post;
 import site.festifriends.entity.PostImage;
 import site.festifriends.entity.PostReaction;
+import site.festifriends.entity.enums.NotificationType;
 import site.festifriends.entity.enums.Role;
 
 @Service
@@ -41,6 +44,7 @@ public class PostService {
     private final GroupRepository groupRepository;
     private final MemberRepository memberRepository;
     private final PostImageRepository postImageRepository;
+    private final NotificationService notificationService;
 
     /**
      * 모임 내 게시글 목록 조회
@@ -128,6 +132,17 @@ public class PostService {
 
             postImageRepository.saveAll(images);
         }
+
+        List<Member> members = applicationRepository.findMembersByGroupId(groupId);
+        NotificationEvent event = notificationService.createNotifications(
+            members,
+            NotificationType.POST,
+            group.getTitle(),
+            savedPost.getId(),
+            groupId
+        );
+
+        notificationService.sendNotifications(members, event);
 
         return PostCreateResponse.success();
     }

--- a/src/main/java/site/festifriends/domain/review/service/ReviewService.java
+++ b/src/main/java/site/festifriends/domain/review/service/ReviewService.java
@@ -14,6 +14,8 @@ import site.festifriends.common.exception.ErrorCode;
 import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.domain.group.repository.GroupRepository;
 import site.festifriends.domain.member.repository.MemberRepository;
+import site.festifriends.domain.notifications.dto.NotificationEvent;
+import site.festifriends.domain.notifications.service.NotificationService;
 import site.festifriends.domain.review.dto.CreateReviewRequest;
 import site.festifriends.domain.review.dto.RecentReviewResponse;
 import site.festifriends.domain.review.dto.UserReviewResponse;
@@ -26,6 +28,7 @@ import site.festifriends.entity.Group;
 import site.festifriends.entity.Member;
 import site.festifriends.entity.Performance;
 import site.festifriends.entity.Review;
+import site.festifriends.entity.enums.NotificationType;
 import site.festifriends.entity.enums.ReviewTag;
 
 @Service
@@ -36,6 +39,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final GroupRepository groupRepository;
     private final MemberRepository memberRepository;
+    private final NotificationService notificationService;
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
@@ -181,6 +185,19 @@ public class ReviewService {
             .build();
 
         reviewRepository.save(review);
+
+        NotificationEvent event = notificationService.createNotification(
+            targetUser,
+            NotificationType.MY_PROFILE,
+            reviewer.getNickname(),
+            null,
+            null
+        );
+
+        notificationService.sendNotification(
+            targetUserId,
+            event
+        );
     }
 
     /**

--- a/src/main/java/site/festifriends/entity/Notification.java
+++ b/src/main/java/site/festifriends/entity/Notification.java
@@ -57,11 +57,12 @@ public class Notification extends SoftDeleteEntity {
     private Long subTargetId;
 
     @Builder
-    public Notification(Member member, NotificationType type, String message, Long targetId) {
+    public Notification(Member member, NotificationType type, String message, Long targetId, Long subTargetId) {
         this.member = member;
         this.type = type;
         this.message = message;
         this.targetId = targetId;
+        this.subTargetId = subTargetId;
         this.isRead = false;
     }
 

--- a/src/main/java/site/festifriends/entity/Notification.java
+++ b/src/main/java/site/festifriends/entity/Notification.java
@@ -52,6 +52,10 @@ public class Notification extends SoftDeleteEntity {
     @Comment("알림 대상 ID (공지, 댓글 등)")
     private Long targetId;
 
+    @Column(name = "sub_target_id")
+    @Comment("알림 서브 대상 ID (예: 새 글의 경우 그룹 ID )")
+    private Long subTargetId;
+
     @Builder
     public Notification(Member member, NotificationType type, String message, Long targetId) {
         this.member = member;

--- a/src/main/java/site/festifriends/entity/Notification.java
+++ b/src/main/java/site/festifriends/entity/Notification.java
@@ -16,14 +16,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
-import site.festifriends.common.model.BaseEntity;
+import site.festifriends.common.model.SoftDeleteEntity;
 import site.festifriends.entity.enums.NotificationType;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "notification")
-public class Notification extends BaseEntity {
+public class Notification extends SoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/festifriends/entity/enums/NotificationType.java
+++ b/src/main/java/site/festifriends/entity/enums/NotificationType.java
@@ -4,14 +4,15 @@ package site.festifriends.entity.enums;
  * 알림 타입을 나타내는 Enum
  */
 public enum NotificationType {
-    PARTY_INVITATION("모임 초대"),
-    PARTY_APPLICATION("모임 신청"),
-    PARTY_APPROVAL("모임 승인"),
-    PARTY_REJECTION("모임 거절"),
-    NEW_NOTICE("새 공지"),
-    NEW_COMMENT("새 댓글"),
-    NEW_REVIEW("새 리뷰"),
-    SCHEDULE_REMINDER("일정 알림");
+    APPLICATION("모임 가입 신청"),
+    APPLIED("모임 가입 승인"),
+    REJECTED("모임 가입 거절"),
+    BANNED("모임 차단됨"),
+    GROUP("모임"),
+    MY_PROFILE("나에 대한 리뷰"),
+    REVIEW("그룹 리뷰 요청"),
+    POST("모임 내 새 게시글"),
+    SCHEDULE("모임 새 일정");
 
     private final String description;
 

--- a/src/main/java/site/festifriends/entity/enums/NotificationType.java
+++ b/src/main/java/site/festifriends/entity/enums/NotificationType.java
@@ -4,15 +4,15 @@ package site.festifriends.entity.enums;
  * 알림 타입을 나타내는 Enum
  */
 public enum NotificationType {
-    APPLICATION("모임 가입 신청"),
-    APPLIED("모임 가입 승인"),
-    REJECTED("모임 가입 거절"),
-    BANNED("모임 차단됨"),
-    GROUP("모임"),
-    MY_PROFILE("나에 대한 리뷰"),
-    REVIEW("그룹 리뷰 요청"),
-    POST("모임 내 새 게시글"),
-    SCHEDULE("모임 새 일정");
+    APPLICATION("모임에 가입 신청이 도착했어요. 수락 또는 거절을 선택해 주세요."),
+    APPLIED("모임의 가입 신청이 수락되었습니다. 가입을 확정해 주세요!"),
+    REJECTED("모임의 가입 신청이 거절되었습니다."),
+    BANNED("모임에서 강퇴되었습니다."),
+    GROUP("모임의 방장으로 임명되었습니다."),
+    MY_PROFILE("님이 회원님에 대한 리뷰를 남겼어요."),
+    REVIEW("모임의 활동이 종료되었습니다. 함께한 모임원에게 리뷰를 남겨 주세요."),
+    POST("모임에 새로운 글이 올라왔어요. 확인해 보세요!"),
+    SCHEDULE("모임에 새로운 일정이 등록되었어요. 확인이 필요해요.");
 
     private final String description;
 

--- a/src/test/java/site/festifriends/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/site/festifriends/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,199 @@
+package site.festifriends.domain.notification.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import site.festifriends.domain.notifications.dto.NotificationEvent;
+import site.festifriends.domain.notifications.repository.NotificationRepository;
+import site.festifriends.domain.notifications.service.NotificationService;
+import site.festifriends.entity.Group;
+import site.festifriends.entity.Member;
+import site.festifriends.entity.Performance;
+import site.festifriends.entity.Post;
+import site.festifriends.entity.enums.Gender;
+import site.festifriends.entity.enums.GroupCategory;
+import site.festifriends.entity.enums.NotificationType;
+import site.festifriends.entity.enums.PerformanceState;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    private Member member;
+    private Performance performance;
+    private Group group;
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+            .id(1L)
+            .email("test1@example.com")
+            .nickname("테스트1")
+            .age(28)
+            .gender(Gender.MALE)
+            .introduction("테스트 1번 멤버")
+            .tags(List.of("음악", "여행"))
+            .sns(List.of("github", "instagram"))
+            .socialId("socialId1")
+            .build();
+
+        performance = Performance.builder()
+            .title("테스트 공연 1")
+            .startDate(LocalDateTime.of(2025, 5, 30, 18, 0))
+            .endDate(LocalDateTime.of(2025, 6, 1, 22, 0))
+            .location("올림픽공원")
+            .cast(List.of("배우1", "배우2"))
+            .crew(List.of("감독1", "작가1"))
+            .runtime("180분")
+            .age("만 12세 이상")
+            .productionCompany(List.of("제작사1"))
+            .agency(List.of("기획사1"))
+            .host(List.of("주최1"))
+            .organizer(List.of("주관사1"))
+            .price(List.of("VIP 10만원", "R석 8만원", "S석 5만원"))
+            .poster("https://example.com/poster1.jpg")
+            .state(PerformanceState.UPCOMING)
+            .visit("국내")
+            .time(List.of(
+                "화요일 ~ 금요일(20:00)",
+                "토요일(16:00,19:00)",
+                "일요일(15:00,18:00)"
+            ))
+            .build();
+
+        group = Group.builder()
+            .title("테스트")
+            .genderType(Gender.ALL)
+            .startAge(20)
+            .endAge(30)
+            .gatherType(GroupCategory.COMPANION)
+            .startDate(LocalDateTime.now())
+            .endDate(LocalDateTime.now().plusDays(1))
+            .location("서울")
+            .count(10)
+            .introduction("모임 소개")
+            .performance(performance)
+            .build();
+
+        post = Post.builder()
+            .group(group)
+            .author(member)
+            .content("테스트 게시글 내용")
+            .build();
+    }
+
+    @Test
+    @DisplayName("[성공] 알림 생성 - 알림 타입이 APPLICATION인 경우")
+    void createNotification_applicationType() {
+        // Given
+        NotificationType type = NotificationType.APPLICATION;
+
+        // When
+        NotificationEvent event = notificationService.createNotification(member, type, group.getTitle(), null, null);
+
+        // Then
+        assertThat(event).isNotNull();
+        assertThat(event.getMessage()).isEqualTo("테스트" + type.getDescription());
+    }
+
+    @Test
+    @DisplayName("[성공] 알림 생성 - 알림 타입이 APPLIED 경우")
+    void createNotification_appliedType() {
+        // Given
+        NotificationType type = NotificationType.APPLIED;
+
+        // When
+        NotificationEvent event = notificationService.createNotification(member, type, group.getTitle(), null, null);
+
+        // Then
+        assertThat(event).isNotNull();
+        assertThat(event.getMessage()).isEqualTo("테스트" + type.getDescription());
+    }
+
+    @Test
+    @DisplayName("[성공] 알림 생성 - 알림 타입이 REJECTED인 경우")
+    void createNotification_rejectedType() {
+        // Given
+        NotificationType type = NotificationType.REJECTED;
+
+        // When
+        NotificationEvent event = notificationService.createNotification(member, type, group.getTitle(), null, null);
+
+        // Then
+        assertThat(event).isNotNull();
+        assertThat(event.getMessage()).isEqualTo("테스트" + type.getDescription());
+    }
+
+    @Test
+    @DisplayName("[성공] 알림 생성 - 알림 타입이 BANNED인 경우")
+    void createNotification_bannedType() {
+        // Given
+        NotificationType type = NotificationType.BANNED;
+
+        // When
+        NotificationEvent event = notificationService.createNotification(member, type, group.getTitle(), null, null);
+
+        // Then
+        assertThat(event).isNotNull();
+        assertThat(event.getMessage()).isEqualTo("테스트" + type.getDescription());
+    }
+
+    @Test
+    @DisplayName("[성공] 알림 생성 - 알림 타입이 GROUP인 경우")
+    void createNotification_groupType() {
+        // Given
+        NotificationType type = NotificationType.GROUP;
+
+        // When
+        NotificationEvent event = notificationService.createNotification(member, type, group.getTitle(), group.getId(),
+            null);
+
+        // Then
+        assertThat(event).isNotNull();
+        assertThat(event.getMessage()).isEqualTo("테스트" + type.getDescription());
+    }
+
+    @Test
+    @DisplayName("[성공] 알림 생성 - 알림 타입이 MY_PROFILE인 경우")
+    void createNotification_myProfileType() {
+        // Given
+        NotificationType type = NotificationType.MY_PROFILE;
+
+        // When
+        NotificationEvent event = notificationService.createNotification(member, type, member.getNickname(), null,
+            null);
+
+        // Then
+        assertThat(event).isNotNull();
+        assertThat(event.getMessage()).isEqualTo(member.getNickname() + type.getDescription());
+    }
+
+    @Test
+    @DisplayName("[성공] 알림 생성 - 알림 타입이 POST인 경우")
+    void createNotification_postType() {
+        // Given
+        NotificationType type = NotificationType.POST;
+
+        // When
+        NotificationEvent event = notificationService.createNotification(member, type, "게시글 제목", post.getId(),
+            group.getId());
+
+        // Then
+        assertThat(event).isNotNull();
+        assertThat(event.getMessage()).isEqualTo("게시글 제목" + type.getDescription());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- [✨feat: 알림 조회 로직 작성](https://github.com/FestiFriends/ff_backend/commit/e378d3847336dbbcc04f5fe26ad9c292ae0f82f1)
- [✨feat: 알림 전체/개별 읽음 처리 및 삭제 기능 구현](https://github.com/FestiFriends/ff_backend/commit/2169451ced05fce4462bdea8c398831c54192112)
- [✨feat: 읽지 않은 알림 여부 확인 기능 구현](https://github.com/FestiFriends/ff_backend/commit/639e8661988134469a18317c17de554d216d9e11)
  - 알림 조회 및 유저 확인 여부 관련 api를 작성했습니다.
  - 이미 읽은 알림의 경우에도 리스트에서 조회가 가능하며, 별도로 제거하지 않는 이상 계속해서 노출됩니다.
  - 또한, 사용자에게 읽지 않은 알림이 존재하는지 여부를 반환합니다.

- [✨feat: sse 연결 api 작성](https://github.com/FestiFriends/ff_backend/commit/fe0e30899b0d8f281c84118079db15f1589ebf40)
- [✨feat: 알림 생성 및 sse event을 통한 전달 기능 구현](https://github.com/FestiFriends/ff_backend/commit/1c30c357c7f2b0aceba83e602d98349d16b634de)
  - SSE 연결을 통해 현재 접속중인 사용자에게 이벤트를 발송할 수 있도록 하였습니다.
  - ConcurrentHashMap 을 이용해 동시성 문제를 방지하였습니다.
  - 알림 메시지 생성 이후 바로 sse에 연결되었는지 여부를 추적하여 메시지를 전송하도록 설정했습니다.
  - 게시글 작성 알림의 경우, 게시글 작성자에게는 알림이 가지 않도록 설정했습니다.