### PR TITLE
✨feat: 프론트엔드 로컬 개발용 소셜 로그인 엔드포인트 추가

### DIFF
--- a/src/main/java/site/festifriends/domain/auth/KakaoOAuthProvider.java
+++ b/src/main/java/site/festifriends/domain/auth/KakaoOAuthProvider.java
@@ -21,6 +21,9 @@ public class KakaoOAuthProvider {
     @Value("${oauth.kakao.redirect-uri}")
     private String redirectUri;
 
+    @Value("${oauth.kakao.dev.redirect-uri}")
+    private String devRedirectUri;
+
     private static final String AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize";
     private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
@@ -67,4 +70,13 @@ public class KakaoOAuthProvider {
             .body(JsonNode.class);
     }
 
+    public String getDevAuthorizationUrl() {
+        return UriComponentsBuilder
+            .fromUriString(AUTHORIZE_URL)
+            .queryParam("response_type", "code")
+            .queryParam("client_id", clientId)
+            .queryParam("redirect_uri", devRedirectUri)
+            .build()
+            .toUriString();
+    }
 }

--- a/src/main/java/site/festifriends/domain/auth/RefreshTokenCookieFactory.java
+++ b/src/main/java/site/festifriends/domain/auth/RefreshTokenCookieFactory.java
@@ -11,6 +11,17 @@ public class RefreshTokenCookieFactory {
         return ResponseCookie
             .from("Refresh-Token", refreshToken)
             .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .maxAge(60 * 60 * 24 * 7)
+            .sameSite("None")
+            .build();
+    }
+
+    public static ResponseCookie createDevCookie(String refreshToken) {
+        return ResponseCookie
+            .from("Refresh-Token", refreshToken)
+            .httpOnly(true)
             .secure(false)
             .path("/")
             .maxAge(60 * 60 * 24 * 7)

--- a/src/main/java/site/festifriends/domain/auth/controller/AuthApi.java
+++ b/src/main/java/site/festifriends/domain/auth/controller/AuthApi.java
@@ -22,6 +22,15 @@ public interface AuthApi {
     ResponseEntity<?> login();
 
     @Operation(
+        summary = "카카오 로그인 요청(로컬 개발용)",
+        description = "카카오 로그인 페이지로 리다이렉트합니다.",
+        responses = {
+            @ApiResponse(responseCode = "302", description = "카카오 로그인 페이지로 리다이렉트"),
+        }
+    )
+    ResponseEntity<?> localLogin();
+
+    @Operation(
         summary = "카카오 로그인 콜백 처리",
         description = "카카오 로그인 후 콜백 URL에서 인증 코드를 받아 처리합니다.",
         responses = {
@@ -31,6 +40,17 @@ public interface AuthApi {
         }
     )
     ResponseEntity<?> handleCallback(@RequestParam String code);
+
+    @Operation(
+        summary = "카카오 로그인 콜백 처리(로컬 개발용)",
+        description = "카카오 로그인 후 콜백 URL에서 인증 코드를 받아 처리합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<?> localHandleCallback(@RequestParam String code);
 
     @Operation(
         summary = "로그아웃",

--- a/src/main/java/site/festifriends/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/festifriends/domain/auth/controller/AuthController.java
@@ -52,6 +52,35 @@ public class AuthController implements AuthApi {
             ));
     }
 
+    // 임시 개발용
+    @Override
+    @GetMapping("/dev/signup/kakao")
+    public ResponseEntity<?> localLogin() {
+        return ResponseEntity
+            .status(HttpStatus.FOUND)
+            .location(URI.create(authService.getDevAuthorizationUrl()))
+            .build();
+    }
+
+    // 임시 개발용
+    @Override
+    @GetMapping("/dev/callback/kakao")
+    public ResponseEntity<?> localHandleCallback(@RequestParam String code) {
+        AuthInfo info = authService.handleOAuthCallback(code);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Set-Cookie", RefreshTokenCookieFactory.createDevCookie(info.getRefreshToken()).toString());
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(ResponseWrapper.success(
+                HttpStatus.OK,
+                "로그인에 성공했습니다.",
+                new AuthResponse(info.getAccessToken(), info.getIsNewUser())
+            ));
+    }
+
     @Override
     @PostMapping("/logout")
     public ResponseEntity<?> logout(UserDetailsImpl userDetails, HttpServletRequest request) {

--- a/src/main/java/site/festifriends/domain/auth/service/AuthService.java
+++ b/src/main/java/site/festifriends/domain/auth/service/AuthService.java
@@ -67,7 +67,7 @@ public class AuthService {
         if (!refreshTokenProvider.validateToken(refreshToken)) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다.");
         }
-        
+
         if (blackListTokenService.isBlackListed(refreshToken)) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "금지된 리프레시 토큰입니다.");
         }
@@ -84,5 +84,9 @@ public class AuthService {
 
         blackListTokenService.addBlackListToken(accessToken);
         blackListTokenService.addBlackListToken(refreshToken);
+    }
+
+    public String getDevAuthorizationUrl() {
+        return kakaoOAuthProvider.getDevAuthorizationUrl();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,8 @@ oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
     redirect-uri: ${KAKAO_REDIRECT_URI}
+    dev:
+      redirect-uri: ${KAKAO_DEV_REDIRECT_URI}
 
 jwt:
   access:


### PR DESCRIPTION
- [✨feat: 프론트엔드 로컬 개발용 소셜 로그인 엔드포인트 추가](https://github.com/FestiFriends/ff_backend/commit/4d4d7f15e88932b4d767b243ca788bf41c5b1214)
  - 현재 환경이 배포서버를 통해서만 로그인이 가능하도록 구성되어 있습니다.
  - https 와 http 사이에서 발생하는 문제로 인해 프론트엔드 개발에 문제가 있음을 확인했습니다.
  - 로컬 개발환경에서도 카카오 소셜 로그인을 할 수 있도록 redirect_uri를 분리하고 컨트롤러를 추가하였습니다.
  - http 환경에서는 일반 쿠키를 / https 환경에서는 secure 쿠키를 발급하도록 변경했습니다.