### PR TITLE
✨feat: 채팅 기능 구현 및 로그 파일 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'

--- a/src/main/java/site/festifriends/common/config/SecurityConfig.java
+++ b/src/main/java/site/festifriends/common/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/token").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/profiles/me").authenticated()
                     .requestMatchers(HttpMethod.GET, readOnlyUrl).permitAll()
+                    .requestMatchers("/chat/**").permitAll()
                     .anyRequest().authenticated())
             .exceptionHandling(exception ->
                 exception

--- a/src/main/java/site/festifriends/common/config/WebSocketConfig.java
+++ b/src/main/java/site/festifriends/common/config/WebSocketConfig.java
@@ -1,0 +1,38 @@
+package site.festifriends.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import site.festifriends.domain.chat.interceptor.AuthChannelInterceptor;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final AuthChannelInterceptor authChannelInterceptor;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/chat")
+            .setAllowedOriginPatterns("*")
+            .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub", "/member");
+        registry.setApplicationDestinationPrefixes("/pub");
+        registry.setUserDestinationPrefix("/member");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(authChannelInterceptor);
+    }
+
+}

--- a/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
+++ b/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
@@ -22,6 +22,7 @@ import site.festifriends.domain.application.dto.ApplicationStatusResponse;
 import site.festifriends.domain.application.dto.AppliedListResponse;
 import site.festifriends.domain.application.dto.JoinedGroupResponse;
 import site.festifriends.domain.application.repository.ApplicationRepository;
+import site.festifriends.domain.chat.service.ChatService;
 import site.festifriends.domain.group.repository.GroupRepository;
 import site.festifriends.domain.member.repository.MemberRepository;
 import site.festifriends.domain.notifications.dto.NotificationEvent;
@@ -45,6 +46,7 @@ public class ApplicationService {
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
     private final NotificationService notificationService;
+    private final ChatService chatService;
 
     /**
      * 신청서 목록 조회
@@ -352,6 +354,8 @@ public class ApplicationService {
                 application.getMember().getId(),
                 event
             );
+
+            chatService.memberJoinChatRoom(application.getMember(), application.getGroup());
 
         } else if (status == ApplicationStatus.REJECTED) {
             application.reject();

--- a/src/main/java/site/festifriends/domain/chat/controller/ChatApi.java
+++ b/src/main/java/site/festifriends/domain/chat/controller/ChatApi.java
@@ -1,0 +1,32 @@
+package site.festifriends.domain.chat.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.chat.dto.ChatMessageResponse;
+
+public interface ChatApi {
+
+    @Operation(
+        summary = "채팅방 메시지 목록 조회",
+        description = "채팅방의 메시지 목록을 조회합니다.(커서 방식)",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "메시지 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+        }
+    )
+    ResponseEntity<CursorResponseWrapper<ChatMessageResponse>> getChatMessages(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Parameter(description = "채팅방 ID")
+        @RequestParam Long chatRoomId,
+        @Parameter(description = "이전 응답에서 받은 커서값, 없으면 첫 페이지 조회")
+        @RequestParam(required = false) Long cursorId,
+        @Parameter(description = "한 번에 가져올 신청서 개수, 기본값 20")
+        @RequestParam(defaultValue = "20") int size
+    );
+}

--- a/src/main/java/site/festifriends/domain/chat/controller/ChatController.java
+++ b/src/main/java/site/festifriends/domain/chat/controller/ChatController.java
@@ -1,0 +1,41 @@
+package site.festifriends.domain.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.chat.dto.ChatMessageRequest;
+import site.festifriends.domain.chat.dto.ChatMessageResponse;
+import site.festifriends.domain.chat.service.ChatService;
+
+@RestController
+@RequestMapping("/api/v1/chat")
+@RequiredArgsConstructor
+public class ChatController implements ChatApi {
+
+    private final ChatService chatService;
+
+    @MessageMapping("/chat/{chatRoomId}")
+    public ChatMessageResponse chat(@DestinationVariable String chatRoomId, ChatMessageRequest message) {
+        return chatService.sendToChatRoom(chatRoomId, message);
+    }
+
+    @Override
+    @GetMapping("/list")
+    public ResponseEntity<CursorResponseWrapper<ChatMessageResponse>> getChatMessages(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam Long chatRoomId,
+        @RequestParam(required = false) Long cursorId,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(chatService.getChatMessages(chatRoomId, cursorId, size));
+    }
+
+}

--- a/src/main/java/site/festifriends/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/site/festifriends/domain/chat/dto/ChatMessageDto.java
@@ -1,0 +1,18 @@
+package site.festifriends.domain.chat.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.domain.image.dto.ImageDto;
+
+@Getter
+@Builder
+public class ChatMessageDto {
+
+    private Long messageId;
+    private Long senderId;
+    private String senderName;
+    private ImageDto senderImage;
+    private String content;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/site/festifriends/domain/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/site/festifriends/domain/chat/dto/ChatMessageRequest.java
@@ -1,0 +1,12 @@
+package site.festifriends.domain.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageRequest {
+
+    private Long senderId;
+    private String content;
+}

--- a/src/main/java/site/festifriends/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/site/festifriends/domain/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,21 @@
+package site.festifriends.domain.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.domain.image.dto.ImageDto;
+
+@Getter
+@Builder
+public class ChatMessageResponse {
+
+    private Long messageId;
+    private Long senderId;
+    private String senderName;
+    private ImageDto senderImage;
+    private String content;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/site/festifriends/domain/chat/interceptor/AuthChannelInterceptor.java
+++ b/src/main/java/site/festifriends/domain/chat/interceptor/AuthChannelInterceptor.java
@@ -1,0 +1,46 @@
+package site.festifriends.domain.chat.interceptor;
+
+import java.security.Principal;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import site.festifriends.common.jwt.AccessTokenProvider;
+
+@Component
+@RequiredArgsConstructor
+public class AuthChannelInterceptor implements ChannelInterceptor {
+
+    private final AccessTokenProvider accessTokenProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        assert accessor != null;
+        if (accessor.getCommand() == StompCommand.CONNECT) {
+            String token = accessor.getNativeHeader("Authorization").get(0);
+            token = token.substring(7);
+
+            Long memberId = Long.valueOf(accessTokenProvider.getSubject(token));
+
+            Principal principal = new UsernamePasswordAuthenticationToken(
+                memberId.toString(),
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+            );
+
+            accessor.setUser(principal);
+            accessor.getSessionAttributes().put("memberId", memberId);
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/site/festifriends/domain/chat/listener/StompEventListener.java
+++ b/src/main/java/site/festifriends/domain/chat/listener/StompEventListener.java
@@ -1,4 +1,4 @@
-package site.festifriends.domain.chat.listner;
+package site.festifriends.domain.chat.listener;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/site/festifriends/domain/chat/listner/StompEventListener.java
+++ b/src/main/java/site/festifriends/domain/chat/listner/StompEventListener.java
@@ -1,0 +1,38 @@
+package site.festifriends.domain.chat.listner;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class StompEventListener extends DefaultHandshakeHandler {
+
+    @EventListener
+    public void handleSubscribeEvent(SessionSubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        String destination = accessor.getDestination();
+
+        String userId = accessor.getSessionAttributes().get("memberId").toString();
+        Long chatRoomId = Long.parseLong(destination.substring(destination.lastIndexOf("/") + 1));
+
+        log.info("회원{}이 {}번채팅방을 구독했습니다.", userId, chatRoomId);
+    }
+
+    @EventListener
+    public void sessionConnectEvent(SessionConnectedEvent event) {
+    }
+
+    @EventListener
+    public void sessionDisconnectEvent(SessionDisconnectEvent event) {
+    }
+
+}

--- a/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,8 @@
+package site.festifriends.domain.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
+
+}

--- a/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepositoryCustom.java
@@ -1,0 +1,10 @@
+package site.festifriends.domain.chat.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import site.festifriends.domain.chat.dto.ChatMessageDto;
+
+public interface ChatMessageRepositoryCustom {
+
+    Slice<ChatMessageDto> getChatMessages(Long chatRoomId, Long cursorId, Pageable pageable);
+}

--- a/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -1,0 +1,63 @@
+package site.festifriends.domain.chat.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import site.festifriends.domain.chat.dto.ChatMessageDto;
+import site.festifriends.domain.image.dto.ImageDto;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
+
+    private final EntityManager em;
+
+    @Override
+    public Slice<ChatMessageDto> getChatMessages(Long chatRoomId, Long cursorId, Pageable pageable) {
+        int pageSize = pageable.getPageSize() + 1;
+
+        String sql = """
+            SELECT cm.chat_message_id, m.member_id, m.nickname, mi.member_image_id, mi.src, mi.alt, cm.content, cm.created_at
+            FROM chat_message cm
+            JOIN member m ON cm.member_id = m.member_id
+            LEFT JOIN member_image mi ON m.member_id = mi.member_id
+            WHERE cm.chat_room_id = :chatRoomId
+            AND (:cursorId IS NULL OR cm.chat_message_id <= :cursorId)
+            AND cm.deleted IS NULL
+            ORDER BY cm.chat_message_id DESC
+            LIMIT :pageSize
+            """;
+
+        Query query = em.createNativeQuery(sql);
+
+        query.setParameter("chatRoomId", chatRoomId);
+        query.setParameter("cursorId", cursorId);
+        query.setParameter("pageSize", pageSize);
+
+        List<Object[]> results = query.getResultList();
+
+        List<ChatMessageDto> dtos = results.stream()
+            .map(result -> ChatMessageDto.builder()
+                .messageId(((Number) result[0]).longValue())
+                .senderId(((Number) result[1]).longValue())
+                .senderName((String) result[2])
+                .senderImage(result[3] != null ? ImageDto.builder()
+                    .id(((String) result[3]))
+                    .src((String) result[4])
+                    .alt((String) result[5])
+                    .build() : null)
+                .content((String) result[6])
+                .createdAt(((java.sql.Timestamp) result[7]).toLocalDateTime())
+                .build())
+            .toList();
+
+        boolean hasNext = dtos.size() == pageSize;
+
+        return new SliceImpl<>(dtos, pageable, hasNext);
+    }
+}

--- a/src/main/java/site/festifriends/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/site/festifriends/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,11 @@
+package site.festifriends.domain.chat.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.ChatRoom;
+import site.festifriends.entity.Group;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    Optional<ChatRoom> findByGroup(Group group);
+}

--- a/src/main/java/site/festifriends/domain/chat/repository/MemberChatRoomRepository.java
+++ b/src/main/java/site/festifriends/domain/chat/repository/MemberChatRoomRepository.java
@@ -1,0 +1,12 @@
+package site.festifriends.domain.chat.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.ChatRoom;
+import site.festifriends.entity.Member;
+import site.festifriends.entity.MemberChatRoom;
+
+public interface MemberChatRoomRepository extends JpaRepository<MemberChatRoom, Long> {
+
+    Optional<MemberChatRoom> findByMemberAndChatRoom(Member member, ChatRoom chatRoom);
+}

--- a/src/main/java/site/festifriends/domain/chat/service/ChatService.java
+++ b/src/main/java/site/festifriends/domain/chat/service/ChatService.java
@@ -1,0 +1,149 @@
+package site.festifriends.domain.chat.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.festifriends.common.exception.BusinessException;
+import site.festifriends.common.exception.ErrorCode;
+import site.festifriends.common.response.CursorResponseWrapper;
+import site.festifriends.domain.chat.dto.ChatMessageDto;
+import site.festifriends.domain.chat.dto.ChatMessageRequest;
+import site.festifriends.domain.chat.dto.ChatMessageResponse;
+import site.festifriends.domain.chat.repository.ChatMessageRepository;
+import site.festifriends.domain.chat.repository.ChatRoomRepository;
+import site.festifriends.domain.chat.repository.MemberChatRoomRepository;
+import site.festifriends.domain.image.dto.ImageDto;
+import site.festifriends.domain.member.repository.MemberImageRepository;
+import site.festifriends.domain.member.service.MemberService;
+import site.festifriends.entity.ChatMessage;
+import site.festifriends.entity.ChatRoom;
+import site.festifriends.entity.Group;
+import site.festifriends.entity.Member;
+import site.festifriends.entity.MemberChatRoom;
+import site.festifriends.entity.MemberImage;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberChatRoomRepository memberChatRoomRepository;
+    private final MemberService memberService;
+    private final ChatMessageRepository chatMessageRepository;
+    private final SimpMessagingTemplate simpMessagingTemplate;
+    private final MemberImageRepository memberImageRepository;
+
+    private static final String CHAT_ROOM_PREFIX = "/sub/chat/";
+
+    @Transactional
+    public ChatRoom createChatRoom(Group group) {
+        ChatRoom newChatRoom = ChatRoom.builder()
+            .group(group)
+            .build();
+
+        return chatRoomRepository.save(newChatRoom);
+    }
+
+    @Transactional
+    public MemberChatRoom memberJoinChatRoom(Member member, Group group) {
+        ChatRoom chatRoom = chatRoomRepository.findByGroup(group)
+            .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "해당하는 채팅방이 없습니다."));
+
+        MemberChatRoom memberChatRoom = MemberChatRoom.builder()
+            .member(member)
+            .chatRoom(chatRoom)
+            .build();
+
+        return memberChatRoomRepository.save(memberChatRoom);
+    }
+
+    @Transactional
+    public void leaveChatRoom(Member member, Group group) {
+        ChatRoom chatRoom = chatRoomRepository.findByGroup(group)
+            .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "해당하는 채팅방이 없습니다."));
+
+        MemberChatRoom memberChatRoom = memberChatRoomRepository.findByMemberAndChatRoom(member, chatRoom)
+            .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "회원이 채팅방에 참여되어 있지 않습니다."));
+
+        memberChatRoomRepository.delete(memberChatRoom);
+    }
+
+    @Transactional
+    public ChatMessageResponse sendToChatRoom(String chatRoomId, ChatMessageRequest message) {
+        ChatRoom chatRoom = chatRoomRepository.findById(Long.parseLong(chatRoomId))
+            .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "해당하는 채팅방이 없습니다."));
+
+        Member member = memberService.getMemberById(message.getSenderId());
+
+        ChatMessage newMessage = ChatMessage.builder()
+            .chatRoom(chatRoom)
+            .member(member)
+            .build();
+
+        chatMessageRepository.save(newMessage);
+
+        MemberImage senderImage = memberImageRepository.findByMemberId(member.getId()).orElse(null);
+
+        ImageDto senderImageDto = senderImage != null ?
+            ImageDto.builder()
+                .id(senderImage.getId().toString())
+                .src(senderImage.getSrc())
+                .alt(senderImage.getAlt())
+                .build() : null;
+
+        ChatMessageResponse chatMessageResponse = ChatMessageResponse.builder()
+            .messageId(newMessage.getId())
+            .senderId(member.getId())
+            .senderName(member.getNickname())
+            .senderImage(senderImageDto)
+            .content(message.getContent())
+            .createdAt(newMessage.getCreatedAt())
+            .build();
+
+        simpMessagingTemplate.convertAndSend(CHAT_ROOM_PREFIX + chatRoomId, chatMessageResponse);
+
+        return chatMessageResponse;
+    }
+
+    @Transactional(readOnly = true)
+    public CursorResponseWrapper<ChatMessageResponse> getChatMessages(Long chatRoomId, Long cursorId, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+        Slice<ChatMessageDto> slice = chatMessageRepository.getChatMessages(chatRoomId, cursorId, pageable);
+
+        if (slice.isEmpty()) {
+            throw new BusinessException(ErrorCode.NOT_FOUND, "채팅 메시지가 없습니다.");
+        }
+
+        List<ChatMessageResponse> response = new ArrayList<>();
+
+        for (ChatMessageDto chatMessage : slice.getContent()) {
+            response.add(ChatMessageResponse.builder()
+                .messageId(chatMessage.getMessageId())
+                .senderId(chatMessage.getSenderId())
+                .senderName(chatMessage.getSenderName())
+                .senderImage(chatMessage.getSenderImage())
+                .content(chatMessage.getContent())
+                .createdAt(chatMessage.getCreatedAt())
+                .build());
+        }
+
+        Long nextCursorId = null;
+        if (slice.hasNext()) {
+            response.remove(response.size() - 1);
+            nextCursorId = slice.getContent().get(size).getMessageId();
+        }
+
+        return CursorResponseWrapper.success(
+            "채팅 메시지를 성공적으로 조회했습니다.",
+            response,
+            nextCursorId,
+            slice.hasNext()
+        );
+    }
+}

--- a/src/main/java/site/festifriends/entity/ChatMessage.java
+++ b/src/main/java/site/festifriends/entity/ChatMessage.java
@@ -1,0 +1,46 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.festifriends.common.model.SoftDeleteEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chat_message")
+public class ChatMessage extends SoftDeleteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_message_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Builder
+    public ChatMessage(ChatRoom chatRoom, Member member, String content) {
+        this.chatRoom = chatRoom;
+        this.member = member;
+        this.content = content;
+    }
+}

--- a/src/main/java/site/festifriends/entity/ChatRoom.java
+++ b/src/main/java/site/festifriends/entity/ChatRoom.java
@@ -1,0 +1,37 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.festifriends.common.model.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chat_room")
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_room_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @Builder
+    public ChatRoom(Member member, Group group) {
+        this.group = group;
+    }
+}

--- a/src/main/java/site/festifriends/entity/MemberChatRoom.java
+++ b/src/main/java/site/festifriends/entity/MemberChatRoom.java
@@ -1,0 +1,40 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import site.festifriends.common.model.BaseEntity;
+
+@Entity
+@Table(name = "member_chat_room")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_chat_room_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @Builder
+    public MemberChatRoom(Member member, ChatRoom chatRoom) {
+        this.member = member;
+        this.chatRoom = chatRoom;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,12 +23,6 @@ spring:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
 
-
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.type.descriptor.sql.BasicBinder: trace
-
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
@@ -65,6 +59,15 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+
+logging:
+  level:
+    root: INFO
+    org.hibernate.SQL: OFF
+    org.hibernate.type.descriptor.sql.BasicBinder: OFF
+  file:
+    name: /var/log/festi/server.log
+
 ---
 spring:
   config:
@@ -75,3 +78,10 @@ spring:
     username: root
     password: password
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
+  file:
+    name: ./server.log

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,5 +83,3 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql.BasicBinder: trace
-  file:
-    name: ./server.log


### PR DESCRIPTION
- [🔧config: spring websocket 관련 의존성 추가](https://github.com/FestiFriends/ff_backend/pull/34/commits/8dcac0e8f0ea42e729b4ba944e523f4bbfa14533)
  - spring websocket 을 사용하기 위해 관련 의존성을 추가하였습니다.
- [🔧chore: 운영 환경에서 로그 INFO 레벨 및 별도 파일로 저장되도록 설정](https://github.com/FestiFriends/ff_backend/pull/34/commits/c7c7b7bff475cfd532f2619694098c696bf11bf4)
  - 배포 환경에서 DEBUG레벨이 아닌 INFO 레벨로 변경하였습니다.
  - 도커 컨테이너 내부에서 로그 파일을 생성하고 볼륨을 통해 ec2 내부에서도 확인할 수 있도록 하였습니다.
- [✨feat: 채팅 관련 테이블 생성](https://github.com/FestiFriends/ff_backend/pull/34/commits/0e3f4da30bee9c2087028ceda3d671c55191a744)
  - 채팅 메시지, 채팅방, 유저_채팅방 테이블을 생성하고 매핑을 진행했습니다.
- [✨feat: 채팅 기능 구현](https://github.com/FestiFriends/ff_backend/pull/34/commits/3aac2bbc13d505b5e8b0ceeabdd6626ee8bea4d9) 
  - SockJS + STOMP 프로토콜을 이용한 채팅 기능을 작성했습니다.
  - STOMP 프로토콜의 CONNECT 커맨드를 통해 토큰으로 유저를 인증할 수 있도록 했습니다.
  - 스프링 기본 메시지 브로커를 이용하여 pub/sub 구조를 통해 실시간 채팅 기능을 구현했습니다.
  - 채팅방 메시지 리스트를 커서 기반으로 조회할 수 있도록 api를 작성했습니다.