### PR TITLE
♻️refactor: 채팅 관련 응답 필드명 변경(messageId -> chatId)

### DIFF
--- a/src/main/java/site/festifriends/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/site/festifriends/domain/chat/dto/ChatMessageDto.java
@@ -9,7 +9,7 @@ import site.festifriends.domain.image.dto.ImageDto;
 @Builder
 public class ChatMessageDto {
 
-    private Long messageId;
+    private Long chatId;
     private Long senderId;
     private String senderName;
     private ImageDto senderImage;

--- a/src/main/java/site/festifriends/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/site/festifriends/domain/chat/dto/ChatMessageResponse.java
@@ -10,7 +10,7 @@ import site.festifriends.domain.image.dto.ImageDto;
 @Builder
 public class ChatMessageResponse {
 
-    private Long messageId;
+    private Long chatId;
     private Long senderId;
     private String senderName;
     private ImageDto senderImage;

--- a/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -43,7 +43,7 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
 
         List<ChatMessageDto> dtos = results.stream()
             .map(result -> ChatMessageDto.builder()
-                .messageId(((Number) result[0]).longValue())
+                .chatId(((Number) result[0]).longValue())
                 .senderId(((Number) result[1]).longValue())
                 .senderName((String) result[2])
                 .senderImage(result[3] != null ? ImageDto.builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,8 +65,6 @@ logging:
     root: INFO
     org.hibernate.SQL: OFF
     org.hibernate.type.descriptor.sql.BasicBinder: OFF
-  file:
-    name: /var/log/festi/server.log
 
 ---
 spring:


### PR DESCRIPTION
## 작업 내용
- [♻️refactor: 응답 필드명 변경 (messageId -> chatId)](https://github.com/FestiFriends/ff_backend/commit/9cd78773e83f5b3349f1576d5fc214a4aa1d733e)
  - 클라이언트측 요청에 따라 채팅 메시지 응답 관련 필드명을 변경했습니다.
  - 채팅 메시지 목록 조회에서 채팅방Id에 해당하는 채팅방이 없을 경우 예외처리를 추가했습니다.
  - 채팅 메시지가 없는 경우 응답 상태코드를 404 -> 400으로 변경했습니다.
- [🔧config: 배포 환경 logging.file 옵션 제거](https://github.com/FestiFriends/ff_backend/commit/fbee5f21df0a3ee0c439e53c450f8d6a5802709d)
  - 배포 환경에서 docker image가 경량화된 이미지를 사용하고 있어 nohup으로 로그 관리방식을 변경하기 위해 필요없는 옵션을 제거했습니다.