### PR TITLE
🔧 리뷰 API 정렬 기준 개선 및 신청 취소 API 하드 삭제 적용

### DIFF
--- a/src/main/java/site/festifriends/domain/application/controller/ApplicationApi.java
+++ b/src/main/java/site/festifriends/domain/application/controller/ApplicationApi.java
@@ -113,7 +113,7 @@ public interface ApplicationApi {
 
     @Operation(
         summary = "모임 가입 신청 취소&확정안함",
-        description = "신청자가 모임 신청을 취소합니다.",
+        description = "신청자가 모임 신청을 완전히 삭제합니다. 데이터베이스에서 영구적으로 제거됩니다.",
         responses = {
             @ApiResponse(responseCode = "200", description = "모임 신청서 취소 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),

--- a/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
+++ b/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
@@ -410,18 +410,17 @@ public class ApplicationService {
     }
 
     /**
-     * 모임 신청 취소&확정안함
+     * 모임 신청 취소&확정안함 (하드 삭제)
      */
+    @Transactional
     public ResponseWrapper<ApplicationStatusResponse> cancelApplication(Long memberId, Long applicationId) {
         MemberGroup application = applicationRepository.findById(applicationId)
             .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "신청서를 찾을 수 없습니다."));
 
         validateApplicantPermission(memberId, application);
 
-        if (application.getStatus() == ApplicationStatus.PENDING) {
-            application.cancel();
-        } else if (application.getStatus() == ApplicationStatus.ACCEPTED) {
-            application.cancel();
+        if (application.getStatus() == ApplicationStatus.PENDING || application.getStatus() == ApplicationStatus.ACCEPTED) {
+            applicationRepository.delete(application);
         } else {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "취소할 수 없는 신청서 상태입니다.");
         }

--- a/src/main/java/site/festifriends/domain/review/controller/ReviewApi.java
+++ b/src/main/java/site/festifriends/domain/review/controller/ReviewApi.java
@@ -37,7 +37,7 @@ public interface ReviewApi {
 
     @Operation(
         summary = "내가 작성한 리뷰 조회",
-        description = "본인이 작성한 리뷰 목록을 커서 기반 페이지네이션으로 조회합니다. 본인만 조회할 수 있습니다.",
+        description = "본인이 작성한 리뷰 목록을 모임별로 그룹화하여 커서 기반 페이지네이션으로 조회합니다. size 파라미터는 조회할 모임의 개수를 의미하며, 각 모임에서는 해당 모임의 모든 리뷰를 조회합니다.",
         responses = {
             @ApiResponse(responseCode = "200", description = "내가 작성한 리뷰 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증이 필요합니다.")
@@ -66,7 +66,7 @@ public interface ReviewApi {
 
     @Operation(
         summary = "작성 가능한 리뷰 목록 조회",
-        description = "로그인한 사용자가 참가한 모임 중에서 아직 리뷰를 남기지 않은 사용자들의 목록을 조회합니다.",
+        description = "로그인한 사용자가 참가한 모임 중에서 아직 리뷰를 남기지 않은 사용자들의 목록을 모임별로 그룹화하여 조회합니다. size 파라미터는 조회할 모임의 개수를 의미하며, 각 모임에서는 리뷰 작성 가능한 모든 사용자를 조회합니다.",
         responses = {
             @ApiResponse(responseCode = "200", description = "작성 가능한 리뷰 목록 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증이 필요합니다.")

--- a/src/main/java/site/festifriends/domain/review/dto/WritableReviewRequest.java
+++ b/src/main/java/site/festifriends/domain/review/dto/WritableReviewRequest.java
@@ -12,7 +12,7 @@ public class WritableReviewRequest {
     @Schema(description = "커서 ID (기본값: 첫번째 요소)", example = "1234")
     private Long cursorId;
 
-    @Schema(description = "한 페이지당 항목 수 (기본값: 20)", example = "20")
+    @Schema(description = "한 페이지당 모임 수 (기본값: 20)", example = "20")
     private Integer size;
 
     public Long getCursorId() {

--- a/src/main/java/site/festifriends/domain/review/dto/WrittenReviewRequest.java
+++ b/src/main/java/site/festifriends/domain/review/dto/WrittenReviewRequest.java
@@ -11,6 +11,6 @@ public class WrittenReviewRequest {
     @Parameter(description = "커서 ID (기본값: 첫번째 요소)")
     private Long cursorId;
 
-    @Parameter(description = "한 페이지당 항목 수 (기본값: 20)")
+    @Parameter(description = "한 페이지당 모임 수 (기본값: 20)")
     private Integer size = 20;
 }

--- a/src/main/java/site/festifriends/domain/review/service/ReviewService.java
+++ b/src/main/java/site/festifriends/domain/review/service/ReviewService.java
@@ -202,6 +202,8 @@ public class ReviewService {
 
     /**
      * 내가 작성한 리뷰 목록 조회 (커서 기반 페이지네이션)
+     * - size 파라미터는 조회할 모임의 개수를 의미
+     * - 각 모임에서는 해당 모임의 모든 리뷰를 조회
      */
     public CursorResponseWrapper<WrittenReviewResponse> getWrittenReviews(Long reviewerId,
         WrittenReviewRequest request) {
@@ -264,6 +266,8 @@ public class ReviewService {
 
     /**
      * 작성 가능한 리뷰 목록 조회 (커서 기반 페이지네이션)
+     * - size 파라미터는 조회할 모임의 개수를 의미
+     * - 각 모임에서는 리뷰 작성 가능한 모든 멤버를 조회
      */
     public CursorResponseWrapper<WritableReviewResponse> getWritableReviews(Long userId,
         WritableReviewRequest request) {


### PR DESCRIPTION
 ## 📝 변경 사항

### 1. 리뷰 API 정렬 기준 개선
- **API 경로**: `/api/v1/reviews/written`, `/api/v1/reviews/writable`
- **변경 내용**: 
  - 모임: 최근 종료일 순서로 정렬 (endDate DESC)
  - 모임 내 사람들: 닉네임 가나다 순으로 정렬 (nickname ASC)

### 2. 신청 취소 API 하드 삭제 적용
- **API 경로**: `DELETE /api/v1/applications/applied/{applicationId}`
- **변경 내용**: 기존 상태 변경(CANCELLED) → 데이터베이스에서 완전 삭제

## 🎯 주요 수정 파일

### ReviewRepositoryImpl.java
```java
// 기존: ORDER BY g.id DESC, r.createdAt DESC
// 변경: ORDER BY g.endDate DESC, re.nickname ASC

// 기존: ORDER BY g.id DESC
// 변경: ORDER BY g.endDate DESC

// 기존: ORDER BY m.id
// 변경: ORDER BY m.nickname ASC
```

### ReviewService.java
- 모임별 그룹화 후 endDate 기준 재정렬 로직 추가
- 모임 내 리뷰/멤버를 닉네임 순으로 정렬하는 로직 추가

### ApplicationService.java
```java
// 기존: application.cancel()
// 변경: applicationRepository.delete(application)
```

## 📋 상세 변경 내용

### 🔄 리뷰 API 정렬 개선
1. **모임 정렬**: 가장 최근에 종료된 모임부터 표시
2. **사용자 정렬**: 각 모임 내에서 닉네임 가나다 순으로 표시
3. **커서 페이지네이션**: endDate 기준으로 변경하여 정렬과 일치

### 🗑️ 신청 취소 API 하드 삭제
1. **변경**: 데이터베이스에서 완전 제거 (하드 삭제)
