### PR TITLE
♻️refactor: 알림 targetId nullable하게 변경

### DIFF
--- a/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryImpl.java
@@ -46,7 +46,7 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom 
                 .type((String) result[2])
                 .createdAt(((Timestamp) result[3]).toLocalDateTime())
                 .isRead((Boolean) result[4])
-                .targetId(((Number) result[5]).longValue())
+                .targetId(result[5] != null ? ((Number) result[5]).longValue() : null)
                 .subTargetId(result[6] != null ? ((Number) result[6]).longValue() : null)
                 .build())
             .toList();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,7 +59,12 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        
 logging:
   level:
     root: INFO


### PR DESCRIPTION
- [♻️refactor: 알림 targetId nullable하게 변경](https://github.com/FestiFriends/ff_backend/commit/275ef434adf9e0843c5e1e5f9c84db3429702824)
  - targetId 가 null일 수 있기 때문에 null의 경우 분기를 나누어 처리하였습니다.
- [🔧config: 배포 환경에서 sql 로그 뜨지 않도록 설정](https://github.com/FestiFriends/ff_backend/commit/8bd6b8fd59703b6db004ea53cee0f9577e7bd212)
  - 배포 환경에서 jpa sql 로그가 누적되어 로그를 제대로 파악하지 못하는 현상을 확인하고, 옵션을 비활성화하였습니다.