### PR TITLE
✨feat: 알림 메시지 조회 기능 변경 / SSE 더미 이벤트 전송 추가

### DIFF
--- a/src/main/java/site/festifriends/common/config/ScheduleConfig.java
+++ b/src/main/java/site/festifriends/common/config/ScheduleConfig.java
@@ -1,0 +1,10 @@
+package site.festifriends.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class ScheduleConfig {
+
+}

--- a/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/notifications/repository/NotificationRepositoryImpl.java
@@ -25,8 +25,8 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom 
             SELECT n.notification_id, n.message, n.type ,n.created_at, n.is_read, n.target_id, n.sub_target_id
             FROM notification n
             WHERE n.member_id = :memberId
-            AND n.is_read = false
             AND (:cursorId IS NULL OR n.notification_id <= :cursorId)
+            AND n.deleted IS NULL
             ORDER BY n.notification_id DESC
             LIMIT :size
             """;


### PR DESCRIPTION
## 작업 내용
- [🔧config: 스프링 스케쥴러 사용을 위한 설정 추가](https://github.com/FestiFriends/ff_backend/commit/bdb8d64ff846c52113453a99f24f5c9cd8a043aa)
- [♻️refactor: 읽은 알림이어도 삭제되지 않으면 조회 가능하도록 변경](https://github.com/FestiFriends/ff_backend/commit/a6cc1f13343b4c04c3278a13563a9d890c69659c)
  - 읽지 않은 알림만 조회 가능 -> 모든 삭제되지 않은 알림 조회 로 기능을 변경했습니다.
- [✨feat: 90초 간격으로 sse 구독 회원들에게 heartbeat 전송하는 기능 추가](https://github.com/FestiFriends/ff_backend/commit/82906bf552523c0078d28006bd64c54749506fb7)
  - 클라이언트 측 요청으로 sse 재연결 시도하지 않도록 90초 간격으로 더미 이벤트를 전송하도록 설정
  - 스프링 스케쥴러를 이용해 서버 실행 시점 이후 90초마다 이벤트가 발생합니다.