### PR TITLE
✨feat: 채팅 관련 기능 수정 및 추가

### DIFF
--- a/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
+++ b/src/main/java/site/festifriends/domain/application/service/ApplicationService.java
@@ -355,8 +355,6 @@ public class ApplicationService {
                 event
             );
 
-            chatService.memberJoinChatRoom(application.getMember(), application.getGroup());
-
         } else if (status == ApplicationStatus.REJECTED) {
             application.reject();
             message = "모임 가입 신청을 거절하였습니다";
@@ -406,6 +404,8 @@ public class ApplicationService {
 
         application.confirm();
 
+        chatService.memberJoinChatRoom(application.getMember(), application.getGroup());
+
         return ResponseWrapper.success("모임 가입을 확정하였습니다", null);
     }
 
@@ -419,7 +419,8 @@ public class ApplicationService {
 
         validateApplicantPermission(memberId, application);
 
-        if (application.getStatus() == ApplicationStatus.PENDING || application.getStatus() == ApplicationStatus.ACCEPTED) {
+        if (application.getStatus() == ApplicationStatus.PENDING
+            || application.getStatus() == ApplicationStatus.ACCEPTED) {
             applicationRepository.delete(application);
         } else {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "취소할 수 없는 신청서 상태입니다.");

--- a/src/main/java/site/festifriends/domain/chat/service/ChatService.java
+++ b/src/main/java/site/festifriends/domain/chat/service/ChatService.java
@@ -84,6 +84,7 @@ public class ChatService {
         ChatMessage newMessage = ChatMessage.builder()
             .chatRoom(chatRoom)
             .member(member)
+            .content(message.getContent())
             .build();
 
         chatMessageRepository.save(newMessage);
@@ -116,7 +117,7 @@ public class ChatService {
         if (!chatRoomRepository.existsById(chatRoomId)) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "해당하는 채팅방이 없습니다.");
         }
-        
+
         Pageable pageable = PageRequest.of(0, size);
         Slice<ChatMessageDto> slice = chatMessageRepository.getChatMessages(chatRoomId, cursorId, pageable);
 
@@ -149,5 +150,14 @@ public class ChatService {
             nextCursorId,
             slice.hasNext()
         );
+    }
+
+    public void joinChatRoom(Member member, ChatRoom chatRoom) {
+        MemberChatRoom memberChatRoom = MemberChatRoom.builder()
+            .member(member)
+            .chatRoom(chatRoom)
+            .build();
+
+        memberChatRoomRepository.save(memberChatRoom);
     }
 }

--- a/src/main/java/site/festifriends/domain/chat/service/ChatService.java
+++ b/src/main/java/site/festifriends/domain/chat/service/ChatService.java
@@ -160,4 +160,9 @@ public class ChatService {
 
         memberChatRoomRepository.save(memberChatRoom);
     }
+
+    public ChatRoom getChatRoomByGroup(Group group) {
+        return chatRoomRepository.findByGroup(group)
+            .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "해당하는 채팅방이 없습니다."));
+    }
 }

--- a/src/main/java/site/festifriends/domain/group/controller/GroupController.java
+++ b/src/main/java/site/festifriends/domain/group/controller/GroupController.java
@@ -3,7 +3,9 @@ package site.festifriends.domain.group.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -68,7 +70,14 @@ public class GroupController implements GroupApi {
     @Override
     @GetMapping("/api/v1/groups/{groupId}")
     public ResponseEntity<ResponseWrapper<GroupDetailResponse>> getGroupDetail(@PathVariable Long groupId) {
-        GroupDetailResponse response = groupService.getGroupDetail(groupId);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        Long memberId = null;
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetailsImpl userDetails) {
+            memberId = userDetails.getMemberId();
+        }
+
+        GroupDetailResponse response = groupService.getGroupDetail(memberId, groupId);
         return ResponseEntity.ok(ResponseWrapper.success("모임 기본 정보 조회 성공.", response));
     }
 

--- a/src/main/java/site/festifriends/domain/group/dto/GroupDetailResponse.java
+++ b/src/main/java/site/festifriends/domain/group/dto/GroupDetailResponse.java
@@ -23,6 +23,8 @@ public class GroupDetailResponse {
     private String description;  // Group의 introduction
     private List<String> hashtag;
     private Host host;
+    private Boolean isMember;
+    private Long chatRoomId;
 
     @Getter
     @Builder

--- a/src/main/java/site/festifriends/domain/group/service/GroupService.java
+++ b/src/main/java/site/festifriends/domain/group/service/GroupService.java
@@ -32,6 +32,7 @@ import site.festifriends.domain.notifications.dto.NotificationEvent;
 import site.festifriends.domain.notifications.service.NotificationService;
 import site.festifriends.domain.performance.repository.PerformanceRepository;
 import site.festifriends.domain.review.repository.ReviewRepository;
+import site.festifriends.entity.ChatRoom;
 import site.festifriends.entity.Group;
 import site.festifriends.entity.Member;
 import site.festifriends.entity.MemberGroup;
@@ -102,7 +103,8 @@ public class GroupService {
 
         applicationRepository.save(hostMemberGroup);
 
-        chatService.createChatRoom(savedGroup);
+        ChatRoom chatRoom = chatService.createChatRoom(savedGroup);
+        chatService.joinChatRoom(member, chatRoom);
     }
 
     private void validateGroupCreateRequest(GroupCreateRequest request) {

--- a/src/main/java/site/festifriends/domain/group/service/GroupService.java
+++ b/src/main/java/site/festifriends/domain/group/service/GroupService.java
@@ -249,7 +249,7 @@ public class GroupService {
     /**
      * 모임 기본 정보 조회
      */
-    public GroupDetailResponse getGroupDetail(Long groupId) {
+    public GroupDetailResponse getGroupDetail(Long memberId, Long groupId) {
         Group group = groupRepository.findById(groupId)
             .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 모임을 찾을 수 없습니다."));
 
@@ -296,6 +296,8 @@ public class GroupService {
             .poster(performance.getPoster())
             .build();
 
+        ChatRoom chatRoom = chatService.getChatRoomByGroup(group);
+
         return GroupDetailResponse.builder()
             .id(group.getId().toString())
             .performance(performanceInfo)
@@ -312,6 +314,8 @@ public class GroupService {
             .description(group.getIntroduction())
             .hashtag(group.getHashTags())
             .host(host)
+            .chatRoomId(chatRoom != null ? chatRoom.getId() : null)
+            .isMember(applicationRepository.isGroupParticipant(groupId, memberId))
             .build();
     }
 

--- a/src/test/java/site/festifriends/domain/application/service/ApplicationServiceTest.java
+++ b/src/test/java/site/festifriends/domain/application/service/ApplicationServiceTest.java
@@ -19,6 +19,7 @@ import site.festifriends.common.exception.ErrorCode;
 import site.festifriends.common.response.ResponseWrapper;
 import site.festifriends.domain.application.dto.ApplicationStatusRequest;
 import site.festifriends.domain.application.repository.ApplicationRepository;
+import site.festifriends.domain.notifications.service.NotificationService;
 import site.festifriends.domain.review.repository.ReviewRepository;
 import site.festifriends.entity.Group;
 import site.festifriends.entity.Member;
@@ -40,6 +41,9 @@ class ApplicationServiceTest {
     @InjectMocks
     private ApplicationService applicationService;
 
+    @Mock
+    private NotificationService notificationService;
+
     private Member host;
     private Member applicant;
     private Group group;
@@ -48,35 +52,35 @@ class ApplicationServiceTest {
     @BeforeEach
     void setUp() {
         host = Member.builder()
-                .socialId("host1")
-                .nickname("방장")
-                .email("host@test.com")
-                .age(25)
-                .gender(Gender.MALE)
-                .build();
+            .socialId("host1")
+            .nickname("방장")
+            .email("host@test.com")
+            .age(25)
+            .gender(Gender.MALE)
+            .build();
 
         applicant = Member.builder()
-                .socialId("applicant1")
-                .nickname("신청자")
-                .email("applicant@test.com")
-                .age(23)
-                .gender(Gender.FEMALE)
-                .build();
+            .socialId("applicant1")
+            .nickname("신청자")
+            .email("applicant@test.com")
+            .age(23)
+            .gender(Gender.FEMALE)
+            .build();
 
         Performance performance = Performance.builder()
-                .title("테스트 페스티벌")
-                .build();
+            .title("테스트 페스티벌")
+            .build();
 
         group = mock(Group.class);
         lenient().when(group.getId()).thenReturn(1L);
 
         application = MemberGroup.builder()
-                .member(applicant)
-                .group(group)
-                .role(Role.MEMBER)
-                .status(ApplicationStatus.PENDING)
-                .applicationText("참여하고 싶습니다!")
-                .build();
+            .member(applicant)
+            .group(group)
+            .role(Role.MEMBER)
+            .status(ApplicationStatus.PENDING)
+            .applicationText("참여하고 싶습니다!")
+            .build();
     }
 
     @Test
@@ -88,11 +92,11 @@ class ApplicationServiceTest {
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 1L, Role.HOST))
-                .willReturn(true);
+            .willReturn(true);
 
         // when
-        ResponseWrapper<Void> response = 
-                applicationService.updateApplicationStatus(1L, 1L, request);
+        ResponseWrapper<Void> response =
+            applicationService.updateApplicationStatus(1L, 1L, request);
 
         // then
         assertThat(response.getMessage()).isEqualTo("모임 가입 신청을 수락하였습니다");
@@ -109,11 +113,11 @@ class ApplicationServiceTest {
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 1L, Role.HOST))
-                .willReturn(true);
+            .willReturn(true);
 
         // when
-        ResponseWrapper<Void> response = 
-                applicationService.updateApplicationStatus(1L, 1L, request);
+        ResponseWrapper<Void> response =
+            applicationService.updateApplicationStatus(1L, 1L, request);
 
         // then
         assertThat(response.getMessage()).isEqualTo("모임 가입 신청을 거절하였습니다");
@@ -132,9 +136,9 @@ class ApplicationServiceTest {
 
         // when & then
         assertThatThrownBy(() -> applicationService.updateApplicationStatus(1L, 999L, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.NOT_FOUND);
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.NOT_FOUND);
     }
 
     @Test
@@ -146,13 +150,13 @@ class ApplicationServiceTest {
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 2L, Role.HOST))
-                .willReturn(false);
+            .willReturn(false);
 
         // when & then
         assertThatThrownBy(() -> applicationService.updateApplicationStatus(2L, 1L, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.FORBIDDEN);
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.FORBIDDEN);
     }
 
     @Test
@@ -160,25 +164,25 @@ class ApplicationServiceTest {
     void updateApplicationStatus_NotPendingStatus() {
         // given
         application = MemberGroup.builder()
-                .member(applicant)
-                .group(group)
-                .role(Role.MEMBER)
-                .status(ApplicationStatus.ACCEPTED) // 이미 승인된 상태
-                .applicationText("참여하고 싶습니다!")
-                .build();
+            .member(applicant)
+            .group(group)
+            .role(Role.MEMBER)
+            .status(ApplicationStatus.ACCEPTED) // 이미 승인된 상태
+            .applicationText("참여하고 싶습니다!")
+            .build();
 
         ApplicationStatusRequest request = new ApplicationStatusRequest();
         request.setStatus(ApplicationStatus.ACCEPTED);
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 1L, Role.HOST))
-                .willReturn(true);
+            .willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> applicationService.updateApplicationStatus(1L, 1L, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.BAD_REQUEST);
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.BAD_REQUEST);
     }
 
     @Test
@@ -190,12 +194,12 @@ class ApplicationServiceTest {
 
         given(applicationRepository.findById(1L)).willReturn(Optional.of(application));
         given(applicationRepository.existsByGroupIdAndMemberIdAndRole(1L, 1L, Role.HOST))
-                .willReturn(true);
+            .willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> applicationService.updateApplicationStatus(1L, 1L, request))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.BAD_REQUEST);
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.BAD_REQUEST);
     }
 }


### PR DESCRIPTION
- [♻️refactor: 메시지 엔티티가 정상적으로 생성되도록 변경](https://github.com/FestiFriends/ff_backend/commit/5f5a5d9fde3fa3270ef165ca1ff3aa8d94e4ea75)
  - content를 제대로 담지 않아 메시지 엔티티가 제대로 생성되지 않는 문제를 해결했습니다.
- [♻️refactor: 모임 가입 확정 시점에서 사용자 채팅방 참가하도록 변경](https://github.com/FestiFriends/ff_backend/commit/1053fdf6d6bd802ecc8c5b8d3b4cdb5f39a27123)
- [✨feat: 모임 개설 시 채팅방 생성 및 회원 참가 기능 추가](https://github.com/FestiFriends/ff_backend/commit/a23f8f80f7aba742b6e07fa47a4ef906342629f9)
- [✨feat: 모임 기본 정보 조회 시 채팅방 id와 모임의 회원인지 여부 반환하도록 추가](https://github.com/FestiFriends/ff_backend/commit/5d4a017341d7ac35177c6548f53f809c3e70e5f8)