### PR TITLE
✨feat: 회원 참여 그룹 모임 조회 기능 추가

### DIFF
--- a/src/main/java/site/festifriends/domain/member/controller/MemberController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/MemberController.java
@@ -69,10 +69,8 @@ public class MemberController implements MemberApi {
         @RequestParam(defaultValue = "20") int size
     ) {
         return ResponseEntity.ok(
-            ResponseWrapper.success(
-                "요청이 성공적으로 처리되었습니다.",
-                memberService.getMyLikedPerformances(userDetails.getMemberId(), cursorId, size)
-            ));
+            memberService.getMyLikedPerformances(userDetails.getMemberId(), cursorId, size)
+        );
     }
 
     @Override

--- a/src/main/java/site/festifriends/domain/member/controller/ProfileApi.java
+++ b/src/main/java/site/festifriends/domain/member/controller/ProfileApi.java
@@ -6,7 +6,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.common.response.ResponseWrapper;
+import site.festifriends.domain.application.dto.JoinedGroupResponse;
 import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.member.dto.GetMyProfileResponse;
 import site.festifriends.domain.member.dto.GetProfileResponse;
@@ -52,5 +55,19 @@ public interface ProfileApi {
     ResponseEntity<ResponseWrapper<?>> updateMyProfile(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @RequestBody UpdateProfileRequest request
+    );
+
+    @Operation(
+        summary = "유저의 참여 모임 조회",
+        description = "특정 유저의 참여 모임을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "참여 그룹 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "존재하지 않는 회원입니다."),
+        }
+    )
+    ResponseEntity<CursorResponseWrapper<JoinedGroupResponse>> getUserJoinedGroups(
+        @PathVariable Long memberId,
+        @RequestParam(required = false) Long cursorId,
+        @RequestParam(defaultValue = "20") int size
     );
 }

--- a/src/main/java/site/festifriends/domain/member/controller/ProfileController.java
+++ b/src/main/java/site/festifriends/domain/member/controller/ProfileController.java
@@ -11,8 +11,12 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.CursorResponseWrapper;
 import site.festifriends.common.response.ResponseWrapper;
+import site.festifriends.domain.application.dto.JoinedGroupResponse;
+import site.festifriends.domain.application.service.ApplicationService;
 import site.festifriends.domain.auth.UserDetailsImpl;
 import site.festifriends.domain.member.dto.GetMyProfileResponse;
 import site.festifriends.domain.member.dto.GetProfileResponse;
@@ -25,6 +29,7 @@ import site.festifriends.domain.member.service.ProfileService;
 public class ProfileController implements ProfileApi {
 
     private final ProfileService profileService;
+    private final ApplicationService applicationService;
 
     @Override
     @GetMapping("/{userId}")
@@ -67,5 +72,18 @@ public class ProfileController implements ProfileApi {
         return ResponseEntity.ok(ResponseWrapper.success(
             "프로필이 성공적으로 수정되었습니다."
         ));
+    }
+
+    @Override
+    @GetMapping("/{memberId}/joined-groups")
+    public ResponseEntity<CursorResponseWrapper<JoinedGroupResponse>> getUserJoinedGroups(
+        @PathVariable Long memberId,
+        @RequestParam(required = false) Long cursorId,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        CursorResponseWrapper<JoinedGroupResponse> response =
+            applicationService.getJoinedGroupsWithSlice(memberId, cursorId, size);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/site/festifriends/domain/member/service/ProfileService.java
+++ b/src/main/java/site/festifriends/domain/member/service/ProfileService.java
@@ -37,7 +37,7 @@ public class ProfileService {
         Object[] reviewData = reviewRepository.getMemberReviewCount(targetId);
         List<Object[]> reviewTagData = reviewRepository.countEachReviewTag(targetId);
         List<String> reviewContents = reviewRepository.getMemberReviewContent(targetId);
-        Object[] groupData = groupRepository.getMemberGroupCount(targetId);
+        Object[] groupCountData = groupRepository.getMemberGroupCount(targetId);
 
         Map<ReviewTag, Integer> countMap = new EnumMap<>(ReviewTag.class);
         for (Object[] row : reviewTagData) {
@@ -47,9 +47,12 @@ public class ProfileService {
         }
 
         GroupSummaryDto groupDto = GroupSummaryDto.builder()
-            .joinedCount(groupData != null && groupData[0] != null ? ((Number) groupData[0]).intValue() : 0)
-            .totalJoinedCount(groupData != null && groupData[1] != null ? ((Number) groupData[1]).intValue() : 0)
-            .createdCount(groupData != null && groupData[2] != null ? ((Number) groupData[2]).intValue() : 0)
+            .joinedCount(
+                groupCountData != null && groupCountData[0] != null ? ((Number) groupCountData[0]).intValue() : 0)
+            .totalJoinedCount(
+                groupCountData != null && groupCountData[1] != null ? ((Number) groupCountData[1]).intValue() : 0)
+            .createdCount(
+                groupCountData != null && groupCountData[2] != null ? ((Number) groupCountData[2]).intValue() : 0)
             .build();
 
         ReviewSummaryDto reviewSummaryDto = ReviewSummaryDto.builder()

--- a/src/main/java/site/festifriends/domain/member/service/ProfileService.java
+++ b/src/main/java/site/festifriends/domain/member/service/ProfileService.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.festifriends.domain.application.repository.ApplicationRepository;
 import site.festifriends.domain.group.dto.GroupSummaryDto;
 import site.festifriends.domain.group.repository.GroupRepository;
 import site.festifriends.domain.image.dto.ImageDto;
@@ -29,6 +30,7 @@ public class ProfileService {
     private final GroupRepository groupRepository;
     private final MemberService memberService;
     private final MemberImageService memberImageService;
+    private final ApplicationRepository applicationRepository;
 
     @Transactional(readOnly = true)
     public GetProfileResponse getMemberProfile(Long targetId, Long memberId) {


### PR DESCRIPTION
- [♻️refactor: 회원 찜한 공연 목록 조회 응답 중첩 제거](https://github.com/FestiFriends/ff_backend/commit/e993e4f861b4ce58118374f0b57f0c8f7bb0fbbb)
  - CursorWrapper 가 2번 중첩되는 부분을 변경하였습니다.
- [✨feat: 회원 참여 그룹 모임 조회 기능 추가](https://github.com/FestiFriends/ff_backend/commit/199ab61de95c11fada053f9ba90911d17abcdd50)
  - 본인 이외의 다른 회원의 참여 그룹 모임 조회 기능을 추가했습니다.