### PR TITLE
♻️refactor: 프로필 정보 수정 시 Member와 MemberImage 모두 프로필 사진 업데이트 되도록 설정

### DIFF
--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -203,11 +203,12 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateMemberProfile(Long memberId, String name, Integer age, String description, List<String> hashtag,
+    public void updateMemberProfile(Long memberId, String name, Integer age, String description, String profileImageUrl,
+        List<String> hashtag,
         String sns) {
         Member member = getMemberById(memberId);
 
-        member.updateProfile(name, age, description, hashtag, sns);
+        member.updateProfile(name, age, description, profileImageUrl, hashtag, sns);
     }
 
     @Transactional

--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -42,25 +42,31 @@ public class MemberService {
     private final BookmarkRepository bookmarkRepository;
     private final MemberImageRepository memberImageRepository;
 
+    private static final String DEFAULT_PROFILE_IMAGE_URL = "http://img1.kakaocdn.net/thumb/R640x640.q70/?fname=http://t1.kakaocdn.net/account_images/default_profile.jpeg";
+
     @Transactional
     public Member loginOrSignUp(KakaoUserInfo userInfo) {
 
         Member member = memberRepository.findBySocialId(userInfo.getSocialId()).orElse(null);
 
         if (member == null) {
+            String image = userInfo.getProfileImage();
+
+            image = image.equals(DEFAULT_PROFILE_IMAGE_URL) ? null : image;
+
             Member newMember = memberRepository.save(Member.builder()
                 .socialId(userInfo.getSocialId())
                 .nickname(userInfo.getName())
                 .email(userInfo.getEmail())
                 .age(0)
-                .profileImageUrl(userInfo.getProfileImage())
+                .profileImageUrl(image)
                 .gender(Gender.ALL)
                 .introduction("")
                 .build());
 
             MemberImage memberImage = MemberImage.builder()
                 .member(newMember)
-                .src(userInfo.getProfileImage())
+                .src(image)
                 .alt("멤버 이미지")
                 .build();
 

--- a/src/main/java/site/festifriends/domain/member/service/ProfileService.java
+++ b/src/main/java/site/festifriends/domain/member/service/ProfileService.java
@@ -148,7 +148,7 @@ public class ProfileService {
     @Transactional
     public void updateMyProfile(Long memberId, UpdateProfileRequest request) {
         memberService.updateMemberProfile(memberId, request.getName(), request.getAge(), request.getDescription(),
-            request.getHashtag(), request.getSns());
+            request.getProfileImage().getSrc(), request.getHashtag(), request.getSns());
 
         memberImageService.updateProfileImage(memberId, request.getProfileImage());
     }

--- a/src/main/java/site/festifriends/entity/Member.java
+++ b/src/main/java/site/festifriends/entity/Member.java
@@ -86,10 +86,12 @@ public class Member extends SoftDeleteEntity {
         this.refreshToken = refreshToken;
     }
 
-    public void updateProfile(String name, Integer age, String description, List<String> hashtag, String sns) {
+    public void updateProfile(String name, Integer age, String description, String profileImageUrl,
+        List<String> hashtag, String sns) {
         this.nickname = name;
         this.age = age;
         this.introduction = description;
+        this.profileImageUrl = profileImageUrl;
         this.tags = hashtag != null ? hashtag : new ArrayList<>();
         this.sns = sns != null ? List.of(sns) : new ArrayList<>();
     }

--- a/src/main/java/site/festifriends/entity/MemberImage.java
+++ b/src/main/java/site/festifriends/entity/MemberImage.java
@@ -27,7 +27,7 @@ public class MemberImage extends BaseEntity {
     @Column(name = "member_image_id", nullable = false)
     private Long id;
 
-    @Column(name = "src", nullable = false)
+    @Column(name = "src")
     @Comment("소개 이미지 URL")
     private String src;
 


### PR DESCRIPTION
- [♻️refactor: 회원 프로필 이미지 값 nullable 하게 변경](https://github.com/FestiFriends/ff_backend/commit/b6c2e36c7be3a6f0ee6a93ca43ef8b6d7effc2b9)
  - 카카오 기본 프로필일 경우 null로 저장하기 위해 컬럼을 nullable하게 변경했습니다
- [♻️refactor: 회원가입 시 카카오 기본 이미지 주소일 경우 null값으로 저장되도록 설정](https://github.com/FestiFriends/ff_backend/commit/7a1233e74ff46f96b9aaf45f5abfc1218b9efc7d)
- [♻️refactor: 프로필 정보 수정 시 Member와 MemberImage 모두 프로필 사진 업데이트 되도록 설정](https://github.com/FestiFriends/ff_backend/commit/5076acfb610e8ed77c444c690d0f8078bd8ed6bf)