### PR TITLE
# 🎭 공연 상태 자동 업데이트 배치 스케줄러 구현

### DIFF
--- a/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/site/festifriends/domain/performance/repository/PerformanceRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import site.festifriends.entity.Performance;
 
 public interface PerformanceRepository extends JpaRepository<Performance, Long>, PerformanceRepositoryCustom {
-} 
+
+}

--- a/src/main/java/site/festifriends/entity/Performance.java
+++ b/src/main/java/site/festifriends/entity/Performance.java
@@ -176,4 +176,16 @@ public class Performance extends SoftDeleteEntity {
             this.imgs = imgs;
         }
     }
+
+    public void updateState() {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(this.startDate)) {
+            this.state = PerformanceState.UPCOMING;
+        } else if (now.isAfter(this.endDate)) {
+            this.state = PerformanceState.COMPLETED;
+        } else {
+            this.state = PerformanceState.ONGOING;
+        }
+    }
 }

--- a/src/main/java/site/festifriends/scheduler/PerformanceStateScheduler.java
+++ b/src/main/java/site/festifriends/scheduler/PerformanceStateScheduler.java
@@ -1,0 +1,34 @@
+package site.festifriends.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import site.festifriends.scheduler.service.PerformanceStateUpdateService;
+
+/**
+ * 공연 상태 자동 업데이트 스케줄러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PerformanceStateScheduler {
+
+    private final PerformanceStateUpdateService performanceStateUpdateService;
+
+    /**
+     * 매일 자정 1분에 공연 상태 업데이트 실행
+     * cron = "초 분 시 일 월 요일"
+     * 0 1 0 * * * = 매일 00:01:00에 실행
+     */
+    @Scheduled(cron = "0 1 0 * * *")
+    public void updatePerformanceStates() {
+        log.info("공연 상태 자동 업데이트 작업을 시작합니다.");
+        try {
+            int updatedCount = performanceStateUpdateService.updateAllPerformanceStates();
+            log.info("공연 상태 자동 업데이트 작업이 완료되었습니다. 업데이트된 공연 수: {}", updatedCount);
+        } catch (Exception e) {
+            log.error("공연 상태 자동 업데이트 작업 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/site/festifriends/scheduler/service/PerformanceStateUpdateService.java
+++ b/src/main/java/site/festifriends/scheduler/service/PerformanceStateUpdateService.java
@@ -1,0 +1,43 @@
+package site.festifriends.scheduler.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.festifriends.domain.performance.repository.PerformanceRepository;
+import site.festifriends.entity.Performance;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PerformanceStateUpdateService {
+
+    private final PerformanceRepository performanceRepository;
+
+    /**
+     * 모든 공연의 상태를 현재 시간 기준으로 업데이트
+     */
+    public int updateAllPerformanceStates() {
+        log.debug("공연 상태 업데이트 서비스 시작");
+        List<Performance> allPerformances = performanceRepository.findAll();
+        int updatedCount = 0;
+        for (Performance performance : allPerformances) {
+            var previousState = performance.getState();
+            performance.updateState();
+
+            if (!previousState.equals(performance.getState())) {
+                log.info("공연 ID: {}, 제목: '{}' 상태 변경: {} -> {}",
+                    performance.getId(),
+                    performance.getTitle(),
+                    previousState.getDescription(),
+                    performance.getState().getDescription());
+                updatedCount++;
+            }
+        }
+        log.debug("공연 상태 업데이트 서비스 완료. 총 {}개 공연 중 {}개 상태 변경됨",
+            allPerformances.size(), updatedCount);
+        return updatedCount;
+    }
+}


### PR DESCRIPTION

Performance 엔티티의 상태(UPCOMING/ONGOING/COMPLETED)를 현재 날짜 기준으로 자동 업데이트하는 배치

## ✨ 주요 기능
- **자동 스케줄링**: 매일 00:01에 모든 공연 상태 자동 업데이트
- **상태 변경 로직**:
  - `startDate` 이전 → `UPCOMING` (공연 예정)
  - `startDate`~`endDate` 사이 → `ONGOING` (공연 중)
  - `endDate` 이후 → `COMPLETED` (공연 종료)
- **로깅**: 상태가 변경된 공연에 대해서만 INFO 레벨 로그 출력