### PR TITLE
✨feat: 신고 관련 기능 추가

### DIFF
--- a/src/main/java/site/festifriends/common/response/PageResponseWrapper.java
+++ b/src/main/java/site/festifriends/common/response/PageResponseWrapper.java
@@ -1,0 +1,46 @@
+package site.festifriends.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PageResponseWrapper<T> extends BaseResponseWrapper<List<T>> {
+
+    private final Integer page;
+    private final Integer size;
+    private final Integer totalElements;
+    private final Integer totalPages;
+    private final Boolean first;
+    private final Boolean last;
+
+    private PageResponseWrapper(Integer code, String message, List<T> data, Integer page, Integer size,
+        Integer totalElements, Integer totalPages, Boolean first, Boolean last) {
+        super(code, message, data);
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.first = first;
+        this.last = last;
+    }
+
+    private PageResponseWrapper(HttpStatus status, String message, List<T> data, Integer page, Integer size,
+        Integer totalElements, Integer totalPages, Boolean first, Boolean last) {
+        super(status, message, data);
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.first = first;
+        this.last = last;
+    }
+
+    public static <T> PageResponseWrapper<T> success(String message, List<T> data, Integer page, Integer size,
+        Integer totalElements, Integer totalPages, Boolean first, Boolean last) {
+        return new PageResponseWrapper<>(SUCCESS_CODE, message, data, page, size, totalElements, totalPages, first,
+            last);
+    }
+}

--- a/src/main/java/site/festifriends/domain/member/service/MemberService.java
+++ b/src/main/java/site/festifriends/domain/member/service/MemberService.java
@@ -31,6 +31,7 @@ import site.festifriends.entity.Member;
 import site.festifriends.entity.MemberImage;
 import site.festifriends.entity.enums.BookmarkType;
 import site.festifriends.entity.enums.Gender;
+import site.festifriends.entity.enums.MemberRole;
 
 @Service
 @RequiredArgsConstructor
@@ -62,6 +63,8 @@ public class MemberService {
                 .profileImageUrl(image)
                 .gender(Gender.ALL)
                 .introduction("")
+                .memberRole(MemberRole.
+                    USER)
                 .build());
 
             MemberImage memberImage = MemberImage.builder()
@@ -75,6 +78,9 @@ public class MemberService {
             return newMember;
         }
 
+        if (member.getSuspendedAt() != null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "정지된 회원입니다.");
+        }
         return member;
     }
 

--- a/src/main/java/site/festifriends/domain/report/controller/ReportApi.java
+++ b/src/main/java/site/festifriends/domain/report/controller/ReportApi.java
@@ -1,0 +1,84 @@
+package site.festifriends.domain.report.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import site.festifriends.common.response.PageResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.report.dto.CreateReportRequest;
+import site.festifriends.domain.report.dto.GetReportResponse;
+import site.festifriends.domain.report.dto.HandleReportRequest;
+
+@Tag(name = "Report", description = "신고 관련 API")
+public interface ReportApi {
+
+    @Operation(
+        summary = "신고 등록",
+        description = "신고를 등록합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    ResponseEntity<?> createReport(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Valid @RequestBody CreateReportRequest request
+    );
+
+    @Operation(
+        summary = "신고 목록 조회",
+        description = "신고 목록을 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "신고 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    ResponseEntity<PageResponseWrapper<GetReportResponse>> getReportList(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "20") int size
+    );
+
+    @Operation(
+        summary = "신고 상세 조회",
+        description = "신고의 상세 정보를 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "신고 상세 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "신고를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    ResponseEntity<?> getReportDetail(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long reportId
+    );
+
+    @Operation(
+        summary = "신고 처리(승인/반려)",
+        description = "신고를 처리합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "신고 처리 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "신고를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+        }
+    )
+    ResponseEntity<?> handleReport(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long reportId,
+        @RequestBody HandleReportRequest request
+    );
+}

--- a/src/main/java/site/festifriends/domain/report/controller/ReportController.java
+++ b/src/main/java/site/festifriends/domain/report/controller/ReportController.java
@@ -1,0 +1,73 @@
+package site.festifriends.domain.report.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import site.festifriends.common.response.PageResponseWrapper;
+import site.festifriends.common.response.ResponseWrapper;
+import site.festifriends.domain.auth.UserDetailsImpl;
+import site.festifriends.domain.report.dto.CreateReportRequest;
+import site.festifriends.domain.report.dto.GetReportDetailResponse;
+import site.festifriends.domain.report.dto.GetReportResponse;
+import site.festifriends.domain.report.dto.HandleReportRequest;
+import site.festifriends.domain.report.service.ReportService;
+
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+public class ReportController implements ReportApi {
+
+    private final ReportService reportService;
+
+    @Override
+    @PostMapping("")
+    public ResponseEntity<?> createReport(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @Valid @RequestBody CreateReportRequest request
+    ) {
+        reportService.createReport(user.getMemberId(), request);
+        return ResponseEntity.ok(ResponseWrapper.success("신고가 정상적으로 등록되었습니다"));
+    }
+
+    @Override
+    @GetMapping("")
+    public ResponseEntity<PageResponseWrapper<GetReportResponse>> getReportList(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        PageResponseWrapper<GetReportResponse> response = reportService.getReportList(user.getMemberId(), page, size);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/{reportId}")
+    public ResponseEntity<?> getReportDetail(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long reportId
+    ) {
+        GetReportDetailResponse data = reportService.getReportDetail(user.getMemberId(), reportId);
+        return ResponseEntity.ok(ResponseWrapper.success("신고 내역이 정상적으로 조회되었습니다.", data));
+    }
+
+    @Override
+    @PatchMapping("/{reportId}")
+    public ResponseEntity<?> handleReport(
+        @AuthenticationPrincipal UserDetailsImpl user,
+        @PathVariable Long reportId,
+        @RequestBody HandleReportRequest request
+    ) {
+        String message = reportService.handleReport(user.getMemberId(), reportId, request);
+
+        return ResponseEntity.ok(ResponseWrapper.success(message));
+    }
+}

--- a/src/main/java/site/festifriends/domain/report/dto/CreateReportRequest.java
+++ b/src/main/java/site/festifriends/domain/report/dto/CreateReportRequest.java
@@ -1,0 +1,26 @@
+package site.festifriends.domain.report.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import site.festifriends.entity.enums.ReportReasonType;
+import site.festifriends.entity.enums.ReportType;
+
+@Getter
+@Builder
+public class CreateReportRequest {
+
+    private Long targetId;
+    private ReportType category;
+    private ReportReasonType reason;
+    private List<ReportImages> snapshots;
+    private String details;
+
+    @Getter
+    @Builder
+    public static class ReportImages {
+
+        private String alt;
+        private String src;
+    }
+}

--- a/src/main/java/site/festifriends/domain/report/dto/GetReportDetailResponse.java
+++ b/src/main/java/site/festifriends/domain/report/dto/GetReportDetailResponse.java
@@ -1,0 +1,30 @@
+package site.festifriends.domain.report.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetReportDetailResponse {
+
+    private Long id;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    private LocalDateTime createdAt;
+    private String category;
+    private String reason;
+    private List<ReportImages> snapshots;
+    private String details;
+    private String status;
+
+    @Getter
+    @Builder
+    public static class ReportImages {
+
+        private Long id;
+        private String alt;
+        private String src;
+    }
+}

--- a/src/main/java/site/festifriends/domain/report/dto/GetReportResponse.java
+++ b/src/main/java/site/festifriends/domain/report/dto/GetReportResponse.java
@@ -1,0 +1,18 @@
+package site.festifriends.domain.report.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetReportResponse {
+
+    private Long id;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+    private LocalDateTime createdAt;
+    private String category;
+    private String reason;
+    private String status;
+}

--- a/src/main/java/site/festifriends/domain/report/dto/HandleReportRequest.java
+++ b/src/main/java/site/festifriends/domain/report/dto/HandleReportRequest.java
@@ -1,0 +1,12 @@
+package site.festifriends.domain.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import site.festifriends.entity.enums.ReportStatus;
+
+@Getter
+@AllArgsConstructor
+public class HandleReportRequest {
+
+    private ReportStatus reportStatus;
+}

--- a/src/main/java/site/festifriends/domain/report/repository/ReportImageRepository.java
+++ b/src/main/java/site/festifriends/domain/report/repository/ReportImageRepository.java
@@ -1,0 +1,10 @@
+package site.festifriends.domain.report.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.ReportImage;
+
+public interface ReportImageRepository extends JpaRepository<ReportImage, Long> {
+
+    List<ReportImage> findByReportId(Long reportId);
+}

--- a/src/main/java/site/festifriends/domain/report/repository/ReportRepository.java
+++ b/src/main/java/site/festifriends/domain/report/repository/ReportRepository.java
@@ -1,0 +1,8 @@
+package site.festifriends.domain.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.festifriends.entity.Report;
+
+public interface ReportRepository extends JpaRepository<Report, Long>, ReportRepositoryCustom {
+
+}

--- a/src/main/java/site/festifriends/domain/report/repository/ReportRepositoryCustom.java
+++ b/src/main/java/site/festifriends/domain/report/repository/ReportRepositoryCustom.java
@@ -1,0 +1,10 @@
+package site.festifriends.domain.report.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import site.festifriends.entity.Report;
+
+public interface ReportRepositoryCustom {
+
+    Page<Report> getReportPage(Pageable pageable);
+}

--- a/src/main/java/site/festifriends/domain/report/repository/ReportRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/report/repository/ReportRepositoryImpl.java
@@ -1,0 +1,45 @@
+package site.festifriends.domain.report.repository;
+
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import site.festifriends.entity.Report;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportRepositoryImpl implements ReportRepositoryCustom {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public Page<Report> getReportPage(Pageable pageable) {
+        String sql = """
+            SELECT r
+            FROM Report r
+            WHERE r.deleted IS NULL
+            AND r.status = 'PENDING'
+            ORDER BY r.createdAt ASC
+            """;
+
+        String countSql = """
+                SELECT COUNT(r)
+                FROM Report r
+                WHERE r.deleted IS NULL
+                AND r.status = 'PENDING'
+            """;
+
+        List<Report> content = entityManager.createQuery(sql, Report.class)
+            .setFirstResult((int) pageable.getOffset())
+            .setMaxResults(pageable.getPageSize())
+            .getResultList();
+
+        Long total = entityManager.createQuery(countSql, Long.class)
+            .getSingleResult();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/site/festifriends/domain/report/service/ReportService.java
+++ b/src/main/java/site/festifriends/domain/report/service/ReportService.java
@@ -1,0 +1,149 @@
+package site.festifriends.domain.report.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.festifriends.common.exception.BusinessException;
+import site.festifriends.common.exception.ErrorCode;
+import site.festifriends.common.response.PageResponseWrapper;
+import site.festifriends.domain.member.service.MemberService;
+import site.festifriends.domain.report.dto.CreateReportRequest;
+import site.festifriends.domain.report.dto.GetReportDetailResponse;
+import site.festifriends.domain.report.dto.GetReportResponse;
+import site.festifriends.domain.report.dto.HandleReportRequest;
+import site.festifriends.domain.report.repository.ReportImageRepository;
+import site.festifriends.domain.report.repository.ReportRepository;
+import site.festifriends.entity.Member;
+import site.festifriends.entity.Report;
+import site.festifriends.entity.ReportImage;
+import site.festifriends.entity.enums.MemberRole;
+import site.festifriends.entity.enums.ReportStatus;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final MemberService memberService;
+    private final ReportRepository reportRepository;
+    private final ReportImageRepository reportImageRepository;
+
+    @Transactional
+    public void createReport(Long memberId, CreateReportRequest request) {
+
+        Member member = memberService.getMemberById(memberId);
+
+        Report newReport = Report.builder()
+            .member(member)
+            .targetId(request.getTargetId())
+            .type(request.getCategory())
+            .reason(request.getReason())
+            .detail(request.getDetails())
+            .build();
+
+        Report saved = reportRepository.save(newReport);
+
+        List<ReportImage> reportImages = request.getSnapshots().stream()
+            .map(image -> ReportImage.builder()
+                .report(saved)
+                .alt(image.getAlt())
+                .src(image.getSrc())
+                .build())
+            .toList();
+
+        reportImageRepository.saveAll(reportImages);
+    }
+
+    public PageResponseWrapper<GetReportResponse> getReportList(Long memberId, int page, int size) {
+        Member member = memberService.getMemberById(memberId);
+
+        if (member.getMemberRole() != MemberRole.ADMIN) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "관리자만 접근할 수 있습니다.");
+        }
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        Page<Report> reports = reportRepository.getReportPage(pageable);
+
+        List<GetReportResponse> data = reports.getContent().stream()
+            .map(report -> GetReportResponse.builder()
+                .id(report.getId())
+                .createdAt(report.getCreatedAt())
+                .category(report.getType().name())
+                .reason(report.getReason().name())
+                .status(report.getStatus().name())
+                .build())
+            .toList();
+
+        return PageResponseWrapper.success(
+            "신고 목록이 정상적으로 조회되었습니다.",
+            data,
+            reports.getNumber() + 1,
+            reports.getSize(),
+            (int) reports.getTotalElements(),
+            reports.getTotalPages(),
+            reports.isFirst(),
+            reports.isLast()
+        );
+    }
+
+    public GetReportDetailResponse getReportDetail(Long memberId, Long reportId) {
+        Member member = memberService.getMemberById(memberId);
+
+        if (member.getMemberRole() != MemberRole.ADMIN) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "관리자만 접근할 수 있습니다.");
+        }
+
+        Report report = reportRepository.findById(reportId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        List<ReportImage> reportImages = reportImageRepository.findByReportId(reportId);
+
+        List<GetReportDetailResponse.ReportImages> snapshots = reportImages.stream()
+            .map(image -> GetReportDetailResponse.ReportImages.builder()
+                .id(image.getId())
+                .alt(image.getAlt())
+                .src(image.getSrc())
+                .build())
+            .toList();
+
+        return GetReportDetailResponse.builder()
+            .id(report.getId())
+            .createdAt(report.getCreatedAt())
+            .category(report.getType().name())
+            .reason(report.getReason().name())
+            .snapshots(snapshots)
+            .details(report.getDetail())
+            .status(report.getStatus().name())
+            .build();
+    }
+
+    @Transactional
+    public String handleReport(Long memberId, Long reportId, HandleReportRequest request) {
+        Member member = memberService.getMemberById(memberId);
+
+        if (member.getMemberRole() != MemberRole.ADMIN) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "관리자만 접근할 수 있습니다.");
+        }
+
+        Report report = reportRepository.findById(reportId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "신고를 찾을 수 없습니다."));
+
+        if (report.getStatus() == ReportStatus.PENDING) {
+            if (request.getReportStatus() == ReportStatus.APPROVED) {
+                report.process(ReportStatus.APPROVED);
+                return "해당 신고가 승인되었습니다";
+            } else if (request.getReportStatus() == ReportStatus.REJECTED) {
+                report.process(ReportStatus.REJECTED);
+                return "해당 신고가 반려되었습니다";
+            }
+        } else {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 처리된 신고입니다.");
+        }
+
+        return "";
+    }
+}

--- a/src/main/java/site/festifriends/entity/Member.java
+++ b/src/main/java/site/festifriends/entity/Member.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 import site.festifriends.common.model.SoftDeleteEntity;
 import site.festifriends.entity.enums.Gender;
+import site.festifriends.entity.enums.MemberRole;
 
 @Entity
 @Getter
@@ -81,6 +83,15 @@ public class Member extends SoftDeleteEntity {
     @Column(name = "refresh_token")
     @Comment("리프레시 토큰")
     private String refreshToken;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_role", nullable = false)
+    @Comment("회원 역할")
+    private MemberRole memberRole;
+
+    @Column(name = "suspended_at")
+    @Comment("정지 일시")
+    private LocalDateTime suspendedAt;
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;

--- a/src/main/java/site/festifriends/entity/Report.java
+++ b/src/main/java/site/festifriends/entity/Report.java
@@ -44,7 +44,7 @@ public class Report extends SoftDeleteEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
-    @Comment("신고 타입(게시물, 채팅, 모임, 유저, 리뷰)")
+    @Comment("신고 타입(모임, 리뷰, 사용자, 채팅, 게시글, 댓글)")
     private ReportType type;
 
     @Enumerated(EnumType.STRING)
@@ -55,19 +55,24 @@ public class Report extends SoftDeleteEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     @Comment("신고 상태(접수/처리 중/완료)")
-    private ReportStatus status = ReportStatus.PENDING;
+    private ReportStatus status;
 
     @Column(name = "processed_at")
     @Comment("처리 일시")
     private LocalDateTime processedAt;
 
+    @Column(name = "detail")
+    @Comment("신고 상세 사유")
+    private String detail;
+
     @Builder
-    public Report(Member member, Long targetId, ReportType type, ReportReasonType reason) {
+    public Report(Member member, Long targetId, ReportType type, ReportReasonType reason, String detail) {
         this.member = member;
         this.targetId = targetId;
         this.type = type;
         this.reason = reason;
         this.status = ReportStatus.PENDING;
+        this.detail = detail;
     }
 
     /**

--- a/src/main/java/site/festifriends/entity/Report.java
+++ b/src/main/java/site/festifriends/entity/Report.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 import site.festifriends.common.model.SoftDeleteEntity;
+import site.festifriends.entity.enums.ReportReasonType;
 import site.festifriends.entity.enums.ReportStatus;
 import site.festifriends.entity.enums.ReportType;
 
@@ -46,9 +47,10 @@ public class Report extends SoftDeleteEntity {
     @Comment("신고 타입(게시물, 채팅, 모임, 유저, 리뷰)")
     private ReportType type;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "reason", nullable = false)
     @Comment("신고 사유")
-    private String reason;
+    private ReportReasonType reason;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
@@ -60,7 +62,7 @@ public class Report extends SoftDeleteEntity {
     private LocalDateTime processedAt;
 
     @Builder
-    public Report(Member member, Long targetId, ReportType type, String reason) {
+    public Report(Member member, Long targetId, ReportType type, ReportReasonType reason) {
         this.member = member;
         this.targetId = targetId;
         this.type = type;
@@ -70,6 +72,7 @@ public class Report extends SoftDeleteEntity {
 
     /**
      * 신고 처리
+     *
      * @param status 처리 상태
      */
     public void process(ReportStatus status) {

--- a/src/main/java/site/festifriends/entity/ReportImage.java
+++ b/src/main/java/site/festifriends/entity/ReportImage.java
@@ -1,0 +1,44 @@
+package site.festifriends.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "report_image")
+public class ReportImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_image_id", nullable = false)
+    private Long id;
+
+    @Column(name = "src", nullable = false)
+    private String src;
+
+    @Column(name = "alt", nullable = false)
+    private String alt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private Report report;
+
+    @Builder
+    public ReportImage(String src, String alt, Report report) {
+        this.src = src;
+        this.alt = alt;
+        this.report = report;
+    }
+}

--- a/src/main/java/site/festifriends/entity/enums/MemberRole.java
+++ b/src/main/java/site/festifriends/entity/enums/MemberRole.java
@@ -1,0 +1,13 @@
+package site.festifriends.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRole {
+    USER("일반 사용자"),
+    ADMIN("관리자");
+
+    private final String description;
+}

--- a/src/main/java/site/festifriends/entity/enums/ReportReasonType.java
+++ b/src/main/java/site/festifriends/entity/enums/ReportReasonType.java
@@ -1,0 +1,17 @@
+package site.festifriends.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportReasonType {
+    PROFANITY("욕설, 비방, 차별, 혐오"),
+    ADVERTISEMENT("홍보, 영리목적"),
+    ILLEGAL("불법 정보"),
+    SEXUAL("음란, 청소년 유해"),
+    PERSONAL_INFO("개인정보 노출, 유포, 거래"),
+    SPAM("도배, 스팸");
+
+    private final String description;
+}

--- a/src/main/java/site/festifriends/entity/enums/ReportStatus.java
+++ b/src/main/java/site/festifriends/entity/enums/ReportStatus.java
@@ -5,8 +5,8 @@ package site.festifriends.entity.enums;
  */
 public enum ReportStatus {
     PENDING("접수"),
-    PROCESSING("처리 중"),
-    COMPLETED("완료");
+    APPROVED("미처리"),
+    REJECTED("반려");
 
     private final String description;
 

--- a/src/main/java/site/festifriends/entity/enums/ReportType.java
+++ b/src/main/java/site/festifriends/entity/enums/ReportType.java
@@ -4,11 +4,12 @@ package site.festifriends.entity.enums;
  * 신고 타입을 나타내는 Enum
  */
 public enum ReportType {
-    POST("게시물"),
+    GROUP("모임"),
+    REVIEW("리뷰"),
+    USER("사용자"),
     CHAT("채팅"),
-    PARTY("모임"),
-    MEMBER("유저"),
-    REVIEW("리뷰");
+    POST("게시글"),
+    COMMENT("댓글");
 
     private final String description;
 


### PR DESCRIPTION
- [✨feat: 회원 역할 및 정지 일시 컬럼 추가](https://github.com/FestiFriends/ff_backend/commit/6e7a62cb6ef44457a60cb5afda092b2939d2d193)
  - 회원 role 및 정지 일시 관련 컬럼을 추가했습니다. (soft delete 와 정지는 다르다고 판단했습니다.)
- [✨feat: 로그인 시, 정지된 회원일 경우 에러 응답하도록 추가](https://github.com/FestiFriends/ff_backend/commit/5b9703f3b2c2241ed2927fbb62f39d21403b5912)
  - 소셜 로그인 시 member의 suspendedAt이 null이 아닐 경우 로그인 실패하도록 설정했습니다. 
- [✨feat: 신고 관련 테이블 및 enum 클래스 정의](https://github.com/FestiFriends/ff_backend/commit/7ca72344547e8a0576d8bd4b7fa0a51bcc225c9d)
  - 신고 및 신고 이미지 테이블 추가와 enum 클래스를 명세에 맞게 작성했습니다
- [✨feat: 신고 관련 기능 추가](https://github.com/FestiFriends/ff_backend/commit/548ec1a5a00d8f486fb14a34b995faae0b25e4ab)
  - 신고 등록, 리스트 조회(페이징), 상세 조회, 처리 기능을 구현했습니다.