### PR TITLE
🐛fix: 채팅 메시지 목록 조회 시 이미지 id값 에러나는 부분 해결

### DIFF
--- a/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/site/festifriends/domain/chat/repository/ChatMessageRepositoryImpl.java
@@ -47,7 +47,7 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
                 .senderId(((Number) result[1]).longValue())
                 .senderName((String) result[2])
                 .senderImage(result[3] != null ? ImageDto.builder()
-                    .id(((String) result[3]))
+                    .id(((Long) result[3]).toString())
                     .src((String) result[4])
                     .alt((String) result[5])
                     .build() : null)


### PR DESCRIPTION
- [🐛fix: 채팅 메시지 목록 조회 시 이미지 id값 에러나는 부분 해결](https://github.com/FestiFriends/ff_backend/commit/caec3fae7f0c8c3c433720c8126cb99c249b9a37)