### PR TITLE
♻️refactor: 채팅방 메시지가 존재하지 않을 시 빈 배열 보내도록 설정

### DIFF
--- a/src/main/java/site/festifriends/domain/chat/service/ChatService.java
+++ b/src/main/java/site/festifriends/domain/chat/service/ChatService.java
@@ -124,7 +124,12 @@ public class ChatService {
         Slice<ChatMessageDto> slice = chatMessageRepository.getChatMessages(chatRoomId, cursorId, pageable);
 
         if (slice.isEmpty()) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, "채팅 메시지가 없습니다.");
+            return CursorResponseWrapper.success(
+                "채팅 메시지를 성공적으로 조회했습니다.",
+                new ArrayList<>(),
+                null,
+                false
+            );
         }
 
         List<ChatMessageResponse> response = new ArrayList<>();


### PR DESCRIPTION
This pull request updates the behavior of the `getChatMessages` method in `ChatService` to improve error handling and user feedback. Instead of throwing an exception when no chat messages are found, the method now returns a successful response with an empty message list.

### Changes to error handling and user feedback:

* [`src/main/java/site/festifriends/domain/chat/service/ChatService.java`](diffhunk://#diff-053cf1decb889b658b8b849372fe8be2ba6d7f1862514f2ccb587f4d9f260b2cL127-R132): Updated the `getChatMessages` method to return a `CursorResponseWrapper` with a success message and an empty list when no chat messages are found, replacing the previous behavior of throwing a `BusinessException`.